### PR TITLE
Main: Version 2 API endpoints package for Splunk Observability APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,20 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# VS Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+.DS_Store
+.vscode/settings.json

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 .PHONY: default all build clean test fmtcheck testacc sonarqube
 
-PKG_NAME=syntheticsclient
-FILES=./...
+PKG_NAME=syntheticsclientv2
+FILES=./syntheticsclientv2/...
 
-default: test
+default: test 
 
 all: clean build test
 
 build: fmtcheck
-	go build
+	go build -tags=unit_tests
 
 clean:
 	@echo "==> Cleaning out old builds "
@@ -28,11 +28,11 @@ fmtcheck: fmt lint
 
 test: fmtcheck
 	@echo "==> Running all tests"
-	go test $(FILES) -v -timeout=30s -parallel=4 -cover
+	go test $(FILES) -v -tags=unit_tests -timeout=30s -parallel=4 -cover
 
 testacc: clean fmtcheck
 	@echo "==> Running all tests"
-	go test $(FILES) -v -timeout=30s -parallel=8 -cover -coverprofile coverage.txt
+	go test $(FILES) -v -tags=unit_tests -timeout=30s -parallel=8 -cover -coverprofile coverage.txt
 
 sonarqube: testacc
 	docker run -it -v "${PWD}:/usr/src" sonarsource/sonar-scanner-cli

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 .PHONY: default all build clean test fmtcheck testacc sonarqube
 
-PKG_NAME=syntheticsclientv2
-FILES=./syntheticsclientv2/...
+PKG_NAME=syntheticsclient
+FILES=./...
 
 default: test 
 
-all: clean build test
+all: clean build test 
 
 build: fmtcheck
 	go build -tags=unit_tests
@@ -22,7 +22,7 @@ fmt:
 
 lint:
 	@echo "==> Checking source code against linters "
-	@GOGC=30 golangci-lint run $(FILES)
+	@GOGC=30 golangci-lint run ./syntheticsclientv2/...
 
 fmtcheck: fmt lint
 

--- a/README.md
+++ b/README.md
@@ -6,72 +6,44 @@ A Splunk Synthetics (Formerly Rigor) client for golang.
 
 ## Important Note
 
-This client is used to make the API calls that are mentioned here [Splunk Synthetics (Formerly Rigor) public API](https://monitoring-api.rigor.com/). However, some features are not implemented or publicly available yet. 
+V2 client is used to make API calls and CRUD operations to the Splunk Observability Synthetics endpoints (E.G. [API Tests](https://dev.splunk.com/observability/reference/api/synthetics_api_tests/))
+
+**Deprecated** V1 Client is used to make the API calls for the [Splunk Synthetics (Formerly Rigor) public API](https://monitoring-api.rigor.com/). 
 
 ## Example Usages
 ```go
-package syntheticsclient
+package main
 
 import (
 	"fmt"
-
-	"https://github.com/splunk/syntheticsclient.git"
+	"os"
+	"encoding/json"
+	sc2 "github.com/splunk/syntheticsclient/syntheticsclientv2"
 )
 
 func main() {
 	//Expects a token is available from the API_ACCESS_TOKEN environment variable
+	//Expects a realm (e.g. us1) is available from REALM environment variable
 	token := os.Getenv("API_ACCESS_TOKEN")
+	realm := os.Getenv("REALM")
 
 	//Create your client with the token
-	c := NewClient(token)
+	c := sc2.NewClient(token, realm)
 
-	// Initialize your check settings
-	o := CreateHttpCheck{
-	Name:               "test test",
-	Frequency:          5,
-	URL:                "https://www.google.com"}
-
-	// Make the request with your check settings and print result
-  res, _, err := c.CreateHttpCheck(&o)
-	if err != nil {
-		fmt.Println(err)
-	} else {
-		JsonPrint(res)
-	}
-}
-```
-
-Another possibility for initializing your interface is to unmarshal a valid JSON string into the needed struct
-```go
-package syntheticsclient
-
-import (
-	"fmt"
-	"encoding/json"
-
-	"https://github.com/splunk/syntheticsclient.git"
-)
-
-func main() {
-
-	token := os.Getenv("API_ACCESS_TOKEN")
-
-	c := NewClient(token)
-
-	//Take your ugly (but valid) JSON string as bytes and unmarshal into a CreateBrowserCheck struct
-	jsonData := []byte(`{"name":"test","type":"real_browser","frequency":10,"round_robin":true,"auto_retry":false,"enabled":true,"integrations":[],"http_request_headers":{"User-Agent":"Mozilla/5.0 (X11; Linux x86_64; Rigor) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Safari/537.36"},"notifications":{"sms":false,"call":false,"email":true,"notify_after_failure_count":2,"notify_on_location_failure":true,"muted":false,"notify_who":[{"sms":false,"call":false,"email":true,"type":"user","links":{"self_html":"https://monitoring.rigor.com/admin/users/1"},"id":1}],"notification_windows":[],"escalations":[]},"url":"https://www.google.com/","user_agent":"Mozilla/5.0 (X11; Linux x86_64; Rigor) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Safari/537.36","auto_update_user_agent":true,"viewport":{"width":1366,"height":768},"enforce_ssl_validation":true,"browser":{"type":"chrome"},"dns_overrides":{},"wait_for_full_metrics":true,"tags":[],"blackout_periods":[{"timezone":"Eastern Time (US & Canada)","start_time":"2000-01-01T07:00:00.000Z","end_time":"2000-01-01T14:00:00.000Z","repeat_type":"daily","duration_in_minutes":420,"is_repeat":true,"created_at":"2020-11-11T21:54:32.000Z","updated_at":"2021-03-30T19:02:54.000Z"}],"steps":[],"javascript_files":[],"threshold_monitors":[],"excluded_files":[],"cookies":[],"connection":{"download_bandwidth":20000,"upload_bandwidth":5000,"latency":28,"packet_loss":0}}`)
-	var browserCheckDetail CreateBrowserCheck
-	err := json.Unmarshal(jsonData, &browserCheckDetail)
+	//Take your ugly (but valid) JSON string as bytes and unmarshal into a CreateHttpCheckV2 struct
+	jsonData := []byte(`{"test":{"name":"Testing-HTTP-stuff","type":"http","url":"https://www.splunk.com","location_ids":["aws-us-east-1","aws-ap-northeast-3"],"frequency":10,"scheduling_strategy":"round_robin","active":true,"request_method":"GET","body":null,"headers":[{"name":"supercool","value":"batman"},{"name":"ajx-back","value":"peeko"}]}}`)
+	var httpCheckDetail sc2.HttpCheckV2Input
+	err := json.Unmarshal(jsonData, &httpCheckDetail)
 	if err != nil {
 		fmt.Println(err)
 	}
 
 	//Use your converted JSON to make the request and print
-	res, _, err := c.CreateBrowserCheck(&browserCheckDetail)
+	res, _, err := c.CreateHttpCheckV2(&httpCheckDetail)
 	if err != nil {
 		fmt.Println(err)
 	} else {
-		JsonPrint(res)
+		fmt.Println(res)
 	}
 }
 ```

--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -1,0 +1,325 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"time"
+)
+
+// Common and shared struct models used for more complex requests
+type Networkconnection struct {
+	Description       string `json:"description,omitempty"`
+	Downloadbandwidth int    `json:"download_bandwidth,omitempty"`
+	Latency           int    `json:"latency,omitempty"`
+	Packetloss        int    `json:"packet_loss,omitempty"`
+	Uploadbandwidth   int    `json:"upload_bandwidth,omitempty"`
+}
+
+type Advancedsettings struct {
+	Authentication     `json:"authentication"`
+	Cookiesv2          []Cookiesv2      `json:"cookies"`
+	BrowserHeaders     []BrowserHeaders `json:"headers,omitempty"`
+	HostOverrides      []HostOverrides  `json:"host_overrides,omitempty"`
+	UserAgent          string           `json:"user_agent,omitempty"`
+	Verifycertificates bool             `json:"verifyCertificates,omitempty"`
+}
+
+type Authentication struct {
+	Password string `json:"password"`
+	Username string `json:"username"`
+}
+
+type Cookiesv2 struct {
+	Key    string `json:"key"`
+	Value  string `json:"value"`
+	Domain string `json:"domain"`
+	Path   string `json:"path"`
+}
+
+type BrowserHeaders struct {
+	Name   string `json:"name"`
+	Value  string `json:"value"`
+	Domain string `json:"domain"`
+}
+
+type HostOverrides struct {
+	Source         string `json:"source"`
+	Target         string `json:"target"`
+	KeepHostHeader bool   `json:"keep_host_header"`
+}
+
+type Transactions struct {
+	Name    string    `json:"name"`
+	StepsV2 []StepsV2 `json:"steps"`
+}
+
+type BusinessTransactions struct {
+	Name    string    `json:"name"`
+	StepsV2 []StepsV2 `json:"steps"`
+}
+
+type StepsV2 struct {
+	Name         string `json:"name"`
+	Type         string `json:"type"`
+	URL          string `json:"url,omitempty"`
+	Action       string `json:"action,omitempty"`
+	WaitForNav   bool   `json:"wait_for_nav"`
+	SelectorType string `json:"selector_type,omitempty"`
+	Selector     string `json:"selector,omitempty"`
+	Options      `json:"options,omitempty"`
+}
+
+type BusinessTransactionStepsV2 struct {
+	Name         string `json:"name"`
+	Type         string `json:"type"`
+	URL          string `json:"url,omitempty"`
+	Action       string `json:"action,omitempty"`
+	WaitForNav   bool   `json:"wait_for_nav"`
+	SelectorType string `json:"selector_type,omitempty"`
+	Selector     string `json:"selector,omitempty"`
+	Options      `json:"options,omitempty"`
+}
+
+type Options struct {
+	URL string `json:"url,omitempty"`
+}
+
+type Device struct {
+	ID                int    `json:"id,omitempty"`
+	Label             string `json:"label,omitempty"`
+	UserAgent         string `json:"user_agent,omitempty"`
+	Networkconnection `json:"network_connection,omitempty"`
+	Viewportheight    int `json:"viewport_height"`
+	Viewportwidth     int `json:"viewport_width"`
+}
+
+type Requests struct {
+	Configuration `json:"configuration,omitempty"`
+	Setup         []Setup       `json:"setup,omitempty"`
+	Validations   []Validations `json:"validations,omitempty"`
+}
+
+type Configuration struct {
+	Body          string `json:"body"`
+	Headers       `json:"headers,omitempty"`
+	Name          string `json:"name,omitempty"`
+	Requestmethod string `json:"requestMethod,omitempty"`
+	URL           string `json:"url,omitempty"`
+}
+
+type Headers map[string]interface{}
+
+type Setup struct {
+	Extractor string `json:"extractor,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Source    string `json:"source,omitempty"`
+	Type      string `json:"type,omitempty"`
+	Variable  string `json:"variable,omitempty"`
+}
+
+type Validations struct {
+	Actual     string `json:"actual,omitempty"`
+	Comparator string `json:"comparator,omitempty"`
+	Expected   string `json:"expected,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Type       string `json:"type,omitempty"`
+}
+
+type Tests []struct {
+	Active             bool      `json:"active"`
+	Createdat          time.Time `json:"created_at"`
+	Frequency          int       `json:"frequency"`
+	ID                 int       `json:"id"`
+	Locationids        []string  `json:"locationIds"`
+	Name               string    `json:"name"`
+	Schedulingstrategy string    `json:"scheduling_strategy"`
+	Type               string    `json:"type"`
+	Updatedat          time.Time `json:"updated_at"`
+}
+
+type GetChecksV2Options struct {
+	TestType string `json:"testType"`
+	PerPage  int    `json:"perPage"`
+	Page     int    `json:"page"`
+	Search   string `json:"search"`
+	OrderBy  string `json:"orderBy"`
+}
+
+type Errors []struct {
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+type HttpHeaders struct {
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
+}
+
+type Variable struct {
+	Createdat   time.Time `json:"created_at,omitempty"`
+	Description string    `json:"description,omitempty"`
+	ID          int       `json:"id,omitempty"`
+	Name        string    `json:"name"`
+	Secret      bool      `json:"secret"`
+	Updatedat   time.Time `json:"updated_at,omitempty"`
+	Value       string    `json:"value"`
+}
+
+type DeleteCheck struct {
+	Result  string `json:"result"`
+	Message string `json:"message"`
+	Errors  Errors `json:"errors"`
+}
+
+type VariableV2Response struct {
+	Variable `json:"variable"`
+}
+
+type VariableV2Input struct {
+	Variable `json:"variable"`
+}
+
+type ChecksV2Response struct {
+	Nextpagelink int `json:"nextPageLink"`
+	Perpage      int `json:"perPage"`
+	Tests        `json:"tests"`
+	Totalcount   int `json:"totalCount"`
+}
+
+type PortCheckV2Response struct {
+	Test struct {
+		ID                 int       `json:"id"`
+		Name               string    `json:"name"`
+		Active             bool      `json:"active"`
+		Frequency          int       `json:"frequency"`
+		SchedulingStrategy string    `json:"scheduling_strategy"`
+		CreatedAt          time.Time `json:"created_at"`
+		UpdatedAt          time.Time `json:"updated_at"`
+		LocationIds        []string  `json:"location_ids"`
+		Type               string    `json:"type"`
+		Protocol           string    `json:"protocol"`
+		Host               string    `json:"host"`
+		Port               int       `json:"port"`
+	} `json:"test"`
+}
+
+type PortCheckV2Input struct {
+	Test struct {
+		Name               string   `json:"name"`
+		Type               string   `json:"type"`
+		URL                string   `json:"url"`
+		Port               int      `json:"port"`
+		Protocol           string   `json:"protocol"`
+		Host               string   `json:"host"`
+		LocationIds        []string `json:"location_ids"`
+		Frequency          int      `json:"frequency"`
+		SchedulingStrategy string   `json:"scheduling_strategy"`
+		Active             bool     `json:"active"`
+	} `json:"test"`
+}
+
+type HttpCheckV2Response struct {
+	Test struct {
+		ID                 int           `json:"id"`
+		Name               string        `json:"name"`
+		Active             bool          `json:"active"`
+		Frequency          int           `json:"frequency"`
+		SchedulingStrategy string        `json:"scheduling_strategy"`
+		CreatedAt          time.Time     `json:"created_at,omitempty"`
+		UpdatedAt          time.Time     `json:"updated_at,omitempty"`
+		LocationIds        []string      `json:"location_ids"`
+		Type               string        `json:"type"`
+		URL                string        `json:"url"`
+		RequestMethod      string        `json:"request_method"`
+		Body               string        `json:"body,omitempty"`
+		HttpHeaders        []HttpHeaders `json:"headers,omitempty"`
+	} `json:"test"`
+}
+
+type HttpCheckV2Input struct {
+	Test struct {
+		Name               string        `json:"name"`
+		Type               string        `json:"type"`
+		URL                string        `json:"url"`
+		LocationIds        []string      `json:"location_ids"`
+		Frequency          int           `json:"frequency"`
+		SchedulingStrategy string        `json:"scheduling_strategy"`
+		Active             bool          `json:"active"`
+		RequestMethod      string        `json:"request_method"`
+		Body               string        `json:"body,omitempty"`
+		HttpHeaders        []HttpHeaders `json:"headers,omitempty"`
+	} `json:"test"`
+}
+
+type ApiCheckV2Input struct {
+	Test struct {
+		Active             bool       `json:"active"`
+		Deviceid           int        `json:"device_id"`
+		Frequency          int        `json:"frequency"`
+		Locationids        []string   `json:"location_ids"`
+		Name               string     `json:"name"`
+		Requests           []Requests `json:"requests"`
+		Schedulingstrategy string     `json:"scheduling_strategy"`
+	} `json:"test"`
+}
+
+type ApiCheckV2Response struct {
+	Test struct {
+		Active             bool      `json:"active,omitempty"`
+		Createdat          time.Time `json:"created_at"`
+		Device             `json:"device,omitempty"`
+		Frequency          int        `json:"frequency,omitempty"`
+		ID                 int        `json:"id,omitempty"`
+		Locationids        []string   `json:"location_ids,omitempty"`
+		Name               string     `json:"name,omitempty"`
+		Requests           []Requests `json:"requests,omitempty"`
+		Schedulingstrategy string     `json:"scheduling_strategy,omitempty"`
+		Type               string     `json:"type,omitempty"`
+		Updatedat          time.Time  `json:"updated_at,omitempty"`
+	}
+}
+
+type BrowserCheckV2Input struct {
+	Test struct {
+		Name                 string                 `json:"name"`
+		BusinessTransactions []BusinessTransactions `json:"business_transactions"`
+		Urlprotocol          string                 `json:"urlProtocol"`
+		Starturl             string                 `json:"startUrl"`
+		LocationIds          []string               `json:"location_ids"`
+		DeviceID             int                    `json:"device_id"`
+		Frequency            int                    `json:"frequency"`
+		Schedulingstrategy   string                 `json:"scheduling_strategy"`
+		Active               bool                   `json:"active"`
+		Advancedsettings     `json:"advanced_settings"`
+	} `json:"test"`
+}
+
+type BrowserCheckV2Response struct {
+	Test struct {
+		Active               bool `json:"active"`
+		Advancedsettings     `json:"advanced_settings"`
+		BusinessTransactions []BusinessTransactions `json:"business_transactions"`
+		Createdat            time.Time              `json:"created_at"`
+		Device               `json:"device"`
+		Frequency            int            `json:"frequency"`
+		ID                   int            `json:"id"`
+		Locationids          []string       `json:"location_ids"`
+		Name                 string         `json:"name"`
+		Schedulingstrategy   string         `json:"scheduling_strategy"`
+		Transactions         []Transactions `json:"transactions"`
+		Type                 string         `json:"type"`
+		Updatedat            time.Time      `json:"updated_at"`
+	} `json:"test"`
+}

--- a/syntheticsclientv2/create_apicheckv2.go
+++ b/syntheticsclientv2/create_apicheckv2.go
@@ -1,0 +1,52 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+func parseCreateApiCheckV2Response(response string) (*ApiCheckV2Response, error) {
+
+	var createApiCheckV2 ApiCheckV2Response
+	JSONResponse := []byte(response)
+	err := json.Unmarshal(JSONResponse, &createApiCheckV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &createApiCheckV2, err
+}
+
+func (c Client) CreateApiCheckV2(ApiCheckV2Details *ApiCheckV2Input) (*ApiCheckV2Response, *RequestDetails, error) {
+
+	body, err := json.Marshal(ApiCheckV2Details)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	details, err := c.makePublicAPICall("POST", "/tests/api", bytes.NewBuffer(body), nil)
+	if err != nil {
+		return nil, details, err
+	}
+
+	newApiCheckV2, err := parseCreateApiCheckV2Response(details.ResponseBody)
+	if err != nil {
+		return newApiCheckV2, details, err
+	}
+
+	return newApiCheckV2, details, nil
+}

--- a/syntheticsclientv2/create_apicheckv2_test.go
+++ b/syntheticsclientv2/create_apicheckv2_test.go
@@ -1,0 +1,82 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var (
+	createApiV2Body = `{"test":{"active":true,"device_id":1,"frequency":5,"location_ids":["aws-us-east-1"],"name":"boop-test","scheduling_strategy":"round_robin","requests":[{"configuration":{"name":"Get-Test","requestMethod":"GET","url":"https://api.us1.signalfx.com/v2/synthetics/tests/api/489","headers":{"X-SF-TOKEN":"jinglebellsbatmanshells", "beep":"boop"},"body":null},"setup":[{"name":"Extract from response body","type":"extract_json","source":"{{response.body}}","extractor":"$.requests","variable":"custom-varz"}],"validations":[{"name":"Assert response code equals 200","type":"assert_numeric","actual":"{{response.code}}","expected":"200","comparator":"equals"}]}]}}`
+	inputData       = ApiCheckV2Input{}
+)
+
+func TestCreateApiCheckV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests/api", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		_, err := w.Write([]byte(createApiV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	err := json.Unmarshal([]byte(createApiV2Body), &inputData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, _, err := testClient.CreateApiCheckV2(&inputData)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(resp)
+
+	if !reflect.DeepEqual(resp.Test.Name, inputData.Test.Name) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Name, inputData.Test.Name)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Active, inputData.Test.Active) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Active, inputData.Test.Active)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Locationids, inputData.Test.Locationids) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Locationids, inputData.Test.Locationids)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Frequency, inputData.Test.Frequency) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Frequency, inputData.Test.Frequency)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Requests, inputData.Test.Requests) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Requests, inputData.Test.Requests)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Schedulingstrategy, inputData.Test.Schedulingstrategy) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Schedulingstrategy, inputData.Test.Schedulingstrategy)
+	}
+
+}

--- a/syntheticsclientv2/create_browsercheckv2.go
+++ b/syntheticsclientv2/create_browsercheckv2.go
@@ -1,0 +1,52 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+func parseCreateBrowserCheckV2Response(response string) (*BrowserCheckV2Response, error) {
+
+	var createBrowserCheckV2 BrowserCheckV2Response
+	JSONResponse := []byte(response)
+	err := json.Unmarshal(JSONResponse, &createBrowserCheckV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &createBrowserCheckV2, err
+}
+
+func (c Client) CreateBrowserCheckV2(browserCheckV2Details *BrowserCheckV2Input) (*BrowserCheckV2Response, *RequestDetails, error) {
+
+	body, err := json.Marshal(browserCheckV2Details)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	details, err := c.makePublicAPICall("POST", "/tests/browser", bytes.NewBuffer(body), nil)
+	if err != nil {
+		return nil, details, err
+	}
+
+	newBrowserCheckV2, err := parseCreateBrowserCheckV2Response(details.ResponseBody)
+	if err != nil {
+		return newBrowserCheckV2, details, err
+	}
+
+	return newBrowserCheckV2, details, nil
+}

--- a/syntheticsclientv2/create_browsercheckv2_test.go
+++ b/syntheticsclientv2/create_browsercheckv2_test.go
@@ -1,0 +1,86 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var (
+	createBrowserCheckV2Body = `{"test":{"name":"browser-beep-test","business_transactions":[{"name":"Synthetic transaction 1","steps":[{"name":"Go to URL","type":"go_to_url","url":"https://www.splunk.com","action":"go_to_url","wait_for_nav":true},{"name":"Nexter step","type":"click_element","selector_type":"id","wait_for_nav":false,"selector":"free-splunk-click-desktop"}]}],"urlProtocol":"https://","startUrl":"www.splunk.com","location_ids":["aws-us-east-1"],"device_id":1,"frequency":5,"scheduling_strategy":"round_robin","active":true,"advanced_settings":{"verify_certificates":true,"authentication":{"username":"boopuser","password":"{{env.beep-var}}"},"headers":[{"name":"batman","value":"Agentoz","domain":"www.batmansagent.com"}],"cookies":[{"key":"super","value":"duper","domain":"www.batmansagent.com","path":"/boom/goes/beep"}]}}}`
+	inputBrowserCheckV2Data  = BrowserCheckV2Input{}
+)
+
+func TestCreateBrowserCheckV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests/browser", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		_, err := w.Write([]byte(createBrowserCheckV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	err := json.Unmarshal([]byte(createBrowserCheckV2Body), &inputBrowserCheckV2Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, _, err := testClient.CreateBrowserCheckV2(&inputBrowserCheckV2Data)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(resp)
+
+	if !reflect.DeepEqual(resp.Test.Name, inputBrowserCheckV2Data.Test.Name) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Name, inputBrowserCheckV2Data.Test.Name)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Active, inputBrowserCheckV2Data.Test.Active) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Active, inputBrowserCheckV2Data.Test.Active)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Locationids, inputBrowserCheckV2Data.Test.LocationIds) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Locationids, inputBrowserCheckV2Data.Test.LocationIds)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Frequency, inputBrowserCheckV2Data.Test.Frequency) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Frequency, inputBrowserCheckV2Data.Test.Frequency)
+	}
+
+	if !reflect.DeepEqual(resp.Test.BusinessTransactions, inputBrowserCheckV2Data.Test.BusinessTransactions) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.BusinessTransactions, inputBrowserCheckV2Data.Test.BusinessTransactions)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Advancedsettings, inputBrowserCheckV2Data.Test.Advancedsettings) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Advancedsettings, inputBrowserCheckV2Data.Test.Advancedsettings)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Schedulingstrategy, inputBrowserCheckV2Data.Test.Schedulingstrategy) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Schedulingstrategy, inputBrowserCheckV2Data.Test.Schedulingstrategy)
+	}
+
+}

--- a/syntheticsclientv2/create_httpcheckv2.go
+++ b/syntheticsclientv2/create_httpcheckv2.go
@@ -1,0 +1,52 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+func parseCreateHttpCheckV2Response(response string) (*HttpCheckV2Response, error) {
+
+	var createHttpCheckV2 HttpCheckV2Response
+	JSONResponse := []byte(response)
+	err := json.Unmarshal(JSONResponse, &createHttpCheckV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &createHttpCheckV2, err
+}
+
+func (c Client) CreateHttpCheckV2(HttpCheckV2Details *HttpCheckV2Input) (*HttpCheckV2Response, *RequestDetails, error) {
+
+	body, err := json.Marshal(HttpCheckV2Details)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	details, err := c.makePublicAPICall("POST", "/tests/http", bytes.NewBuffer(body), nil)
+	if err != nil {
+		return nil, details, err
+	}
+
+	newHttpCheckV2, err := parseCreateHttpCheckV2Response(details.ResponseBody)
+	if err != nil {
+		return newHttpCheckV2, details, err
+	}
+
+	return newHttpCheckV2, details, nil
+}

--- a/syntheticsclientv2/create_httpcheckv2_test.go
+++ b/syntheticsclientv2/create_httpcheckv2_test.go
@@ -1,0 +1,86 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var (
+	createHttpCheckV2Body = `{"test":{"name":"morebeeps-test","type":"http","url":"https://www.splunk.com","location_ids":["aws-us-east-1"],"frequency":10,"scheduling_strategy":"round_robin","active":true,"request_method":"GET","body":null,"headers":[{"name":"boop","value":"beep"}]}}`
+	inputHttpCheckV2Data  = HttpCheckV2Input{}
+)
+
+func TestCreateHttpCheckV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests/http", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		_, err := w.Write([]byte(createHttpCheckV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	err := json.Unmarshal([]byte(createHttpCheckV2Body), &inputHttpCheckV2Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, _, err := testClient.CreateHttpCheckV2(&inputHttpCheckV2Data)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(resp)
+
+	if !reflect.DeepEqual(resp.Test.Name, inputHttpCheckV2Data.Test.Name) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Name, inputHttpCheckV2Data.Test.Name)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Active, inputHttpCheckV2Data.Test.Active) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Active, inputHttpCheckV2Data.Test.Active)
+	}
+
+	if !reflect.DeepEqual(resp.Test.LocationIds, inputHttpCheckV2Data.Test.LocationIds) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.LocationIds, inputHttpCheckV2Data.Test.LocationIds)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Frequency, inputHttpCheckV2Data.Test.Frequency) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Frequency, inputHttpCheckV2Data.Test.Frequency)
+	}
+
+	if !reflect.DeepEqual(resp.Test.RequestMethod, inputHttpCheckV2Data.Test.RequestMethod) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.RequestMethod, inputHttpCheckV2Data.Test.RequestMethod)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Body, inputHttpCheckV2Data.Test.Body) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Body, inputHttpCheckV2Data.Test.Body)
+	}
+
+	if !reflect.DeepEqual(resp.Test.SchedulingStrategy, inputHttpCheckV2Data.Test.SchedulingStrategy) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.SchedulingStrategy, inputHttpCheckV2Data.Test.SchedulingStrategy)
+	}
+
+}

--- a/syntheticsclientv2/create_portcheckv2.go
+++ b/syntheticsclientv2/create_portcheckv2.go
@@ -1,0 +1,52 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+func parseCreatePortCheckV2Response(response string) (*PortCheckV2Response, error) {
+
+	var createPortCheckV2 PortCheckV2Response
+	JSONResponse := []byte(response)
+	err := json.Unmarshal(JSONResponse, &createPortCheckV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &createPortCheckV2, err
+}
+
+func (c Client) CreatePortCheckV2(PortCheckV2Details *PortCheckV2Input) (*PortCheckV2Response, *RequestDetails, error) {
+
+	body, err := json.Marshal(PortCheckV2Details)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	details, err := c.makePublicAPICall("POST", "/tests/port", bytes.NewBuffer(body), nil)
+	if err != nil {
+		return nil, details, err
+	}
+
+	newPortCheckV2, err := parseCreatePortCheckV2Response(details.ResponseBody)
+	if err != nil {
+		return newPortCheckV2, details, err
+	}
+
+	return newPortCheckV2, details, nil
+}

--- a/syntheticsclientv2/create_portcheckv2_test.go
+++ b/syntheticsclientv2/create_portcheckv2_test.go
@@ -1,0 +1,86 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var (
+	createPortCheckV2Body = `{"test":{"name":"splunk - port 443","type":"port","url":"","port":443,"protocol":"tcp","host":"www.splunk.com","location_ids":["aws-us-east-1"],"frequency":10,"scheduling_strategy":"round_robin","active":true}}`
+	inputPortCheckV2Data  = PortCheckV2Input{}
+)
+
+func TestCreatePortCheckV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests/port", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		_, err := w.Write([]byte(createPortCheckV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	err := json.Unmarshal([]byte(createPortCheckV2Body), &inputPortCheckV2Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, _, err := testClient.CreatePortCheckV2(&inputPortCheckV2Data)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(resp)
+
+	if !reflect.DeepEqual(resp.Test.Name, inputPortCheckV2Data.Test.Name) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Name, inputPortCheckV2Data.Test.Name)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Type, inputPortCheckV2Data.Test.Type) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Type, inputPortCheckV2Data.Test.Type)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Frequency, inputPortCheckV2Data.Test.Frequency) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Frequency, inputPortCheckV2Data.Test.Frequency)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Active, inputPortCheckV2Data.Test.Active) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Active, inputPortCheckV2Data.Test.Active)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Protocol, inputPortCheckV2Data.Test.Protocol) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Protocol, inputPortCheckV2Data.Test.Protocol)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Host, inputPortCheckV2Data.Test.Host) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Host, inputPortCheckV2Data.Test.Host)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Port, inputPortCheckV2Data.Test.Port) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Port, inputPortCheckV2Data.Test.Port)
+	}
+
+}

--- a/syntheticsclientv2/create_variablev2.go
+++ b/syntheticsclientv2/create_variablev2.go
@@ -1,0 +1,52 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+func parseCreateVariableV2Response(response string) (*VariableV2Response, error) {
+
+	var createVariableV2 VariableV2Response
+	JSONResponse := []byte(response)
+	err := json.Unmarshal(JSONResponse, &createVariableV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &createVariableV2, err
+}
+
+func (c Client) CreateVariableV2(VariableV2Details *VariableV2Input) (*VariableV2Response, *RequestDetails, error) {
+
+	body, err := json.Marshal(VariableV2Details)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	details, err := c.makePublicAPICall("POST", "/variables", bytes.NewBuffer(body), nil)
+	if err != nil {
+		return nil, details, err
+	}
+
+	newVariableV2, err := parseCreateVariableV2Response(details.ResponseBody)
+	if err != nil {
+		return newVariableV2, details, err
+	}
+
+	return newVariableV2, details, nil
+}

--- a/syntheticsclientv2/create_variablev2_test.go
+++ b/syntheticsclientv2/create_variablev2_test.go
@@ -1,0 +1,78 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var (
+	createVariableV2Body = `{"variable":{"description":"My super awesome test variable","name":"food","secret":false,"value":"bar"}}`
+	inputVariableV2Data  = VariableV2Input{}
+)
+
+func TestCreateVariableV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/variables", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		_, err := w.Write([]byte(createVariableV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	err := json.Unmarshal([]byte(createVariableV2Body), &inputVariableV2Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, _, err := testClient.CreateVariableV2(&inputVariableV2Data)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(resp)
+
+	if !reflect.DeepEqual(resp.Variable.ID, inputVariableV2Data.Variable.ID) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Variable.ID, inputVariableV2Data.Variable.ID)
+	}
+
+	if !reflect.DeepEqual(resp.Variable.Name, inputVariableV2Data.Variable.Name) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Variable.Name, inputVariableV2Data.Variable.Name)
+	}
+
+	if !reflect.DeepEqual(resp.Variable.Description, inputVariableV2Data.Variable.Description) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Variable.Description, inputVariableV2Data.Variable.Description)
+	}
+
+	if !reflect.DeepEqual(resp.Variable.Value, inputVariableV2Data.Variable.Value) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Variable.Value, inputVariableV2Data.Variable.Value)
+	}
+
+	if !reflect.DeepEqual(resp.Variable.Secret, inputVariableV2Data.Variable.Secret) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Variable.Secret, inputVariableV2Data.Variable.Secret)
+	}
+
+}

--- a/syntheticsclientv2/delete_apicheckv2.go
+++ b/syntheticsclientv2/delete_apicheckv2.go
@@ -1,0 +1,39 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+func (c Client) DeleteApiCheckV2(id int) (int, error) {
+	requestDetails, err := c.makePublicAPICall("DELETE", fmt.Sprintf("/tests/api/%d", id), bytes.NewBufferString("{}"), nil)
+	if err != nil {
+		return 1, err
+	}
+	var status = requestDetails.StatusCode
+
+	fmt.Println(status)
+
+	if status >= 300 || status < 200 {
+		errorMsg := fmt.Sprintf("error: Response code %v. Expecting 2XX.", strconv.Itoa(status))
+		return status, errors.New(errorMsg)
+	}
+
+	return status, err
+}

--- a/syntheticsclientv2/delete_apicheckv2_test.go
+++ b/syntheticsclientv2/delete_apicheckv2_test.go
@@ -1,0 +1,48 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+var (
+	deleteApiCheckV2RespBody = ``
+)
+
+func TestDeleteApiCheckV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests/api/19", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		_, err := w.Write([]byte(deleteApiCheckV2RespBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	resp, err := testClient.DeleteApiCheckV2(19)
+	if err != nil {
+		fmt.Println(resp)
+		t.Fatal(err)
+	}
+	fmt.Println(resp)
+}

--- a/syntheticsclientv2/delete_browsercheckv2.go
+++ b/syntheticsclientv2/delete_browsercheckv2.go
@@ -1,0 +1,39 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+func (c Client) DeleteBrowserCheckV2(id int) (int, error) {
+	requestDetails, err := c.makePublicAPICall("DELETE", fmt.Sprintf("/tests/browser/%d", id), bytes.NewBufferString("{}"), nil)
+	if err != nil {
+		return 1, err
+	}
+	var status = requestDetails.StatusCode
+
+	fmt.Println(status)
+
+	if status >= 300 || status < 200 {
+		errorMsg := fmt.Sprintf("error: Response code %v. Expecting 2XX.", strconv.Itoa(status))
+		return status, errors.New(errorMsg)
+	}
+
+	return status, err
+}

--- a/syntheticsclientv2/delete_browsercheckv2_test.go
+++ b/syntheticsclientv2/delete_browsercheckv2_test.go
@@ -1,0 +1,48 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+var (
+	deleteBrowserCheckV2RespBody = ``
+)
+
+func TestDeleteBrowserCheckV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests/browser/19", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		_, err := w.Write([]byte(deleteBrowserCheckV2RespBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	resp, err := testClient.DeleteBrowserCheckV2(19)
+	if err != nil {
+		fmt.Println(resp)
+		t.Fatal(err)
+	}
+	fmt.Println(resp)
+}

--- a/syntheticsclientv2/delete_httpcheckv2.go
+++ b/syntheticsclientv2/delete_httpcheckv2.go
@@ -1,0 +1,39 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+func (c Client) DeleteHttpCheckV2(id int) (int, error) {
+	requestDetails, err := c.makePublicAPICall("DELETE", fmt.Sprintf("/tests/http/%d", id), bytes.NewBufferString("{}"), nil)
+	if err != nil {
+		return 1, err
+	}
+	var status = requestDetails.StatusCode
+
+	fmt.Println(status)
+
+	if status >= 300 || status < 200 {
+		errorMsg := fmt.Sprintf("error: Response code %v. Expecting 2XX.", strconv.Itoa(status))
+		return status, errors.New(errorMsg)
+	}
+
+	return status, err
+}

--- a/syntheticsclientv2/delete_httpcheckv2_test.go
+++ b/syntheticsclientv2/delete_httpcheckv2_test.go
@@ -1,0 +1,48 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+var (
+	deleteHttpCheckV2RespBody = ``
+)
+
+func TestDeleteHttpCheckV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests/http/19", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		_, err := w.Write([]byte(deleteHttpCheckV2RespBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	resp, err := testClient.DeleteHttpCheckV2(19)
+	if err != nil {
+		fmt.Println(resp)
+		t.Fatal(err)
+	}
+	fmt.Println(resp)
+}

--- a/syntheticsclientv2/delete_portcheckv2.go
+++ b/syntheticsclientv2/delete_portcheckv2.go
@@ -1,0 +1,39 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+func (c Client) DeletePortCheckV2(id int) (int, error) {
+	requestDetails, err := c.makePublicAPICall("DELETE", fmt.Sprintf("/tests/port/%d", id), bytes.NewBufferString("{}"), nil)
+	if err != nil {
+		return 1, err
+	}
+	var status = requestDetails.StatusCode
+
+	fmt.Println(status)
+
+	if status >= 300 || status < 200 {
+		errorMsg := fmt.Sprintf("error: Response code %v. Expecting 2XX.", strconv.Itoa(status))
+		return status, errors.New(errorMsg)
+	}
+
+	return status, err
+}

--- a/syntheticsclientv2/delete_portcheckv2_test.go
+++ b/syntheticsclientv2/delete_portcheckv2_test.go
@@ -1,0 +1,48 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+var (
+	deletePortCheckV2RespBody = ``
+)
+
+func TestDeletePortCheckV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests/port/19", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		_, err := w.Write([]byte(deletePortCheckV2RespBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	resp, err := testClient.DeletePortCheckV2(19)
+	if err != nil {
+		fmt.Println(resp)
+		t.Fatal(err)
+	}
+	fmt.Println(resp)
+}

--- a/syntheticsclientv2/delete_variablesv2_test.go
+++ b/syntheticsclientv2/delete_variablesv2_test.go
@@ -1,0 +1,48 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+var (
+	deleteVariableV2RespBody = ``
+)
+
+func TestDeleteVariableV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/variables/19", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		_, err := w.Write([]byte(deleteVariableV2RespBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	resp, err := testClient.DeleteVariableV2(19)
+	if err != nil {
+		fmt.Println(resp)
+		t.Fatal(err)
+	}
+	fmt.Println(resp)
+}

--- a/syntheticsclientv2/delete_variablev2.go
+++ b/syntheticsclientv2/delete_variablev2.go
@@ -1,0 +1,39 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+func (c Client) DeleteVariableV2(id int) (int, error) {
+	requestDetails, err := c.makePublicAPICall("DELETE", fmt.Sprintf("/variables/%d", id), bytes.NewBufferString("{}"), nil)
+	if err != nil {
+		return 1, err
+	}
+	var status = requestDetails.StatusCode
+
+	fmt.Println(status)
+
+	if status >= 300 || status < 200 {
+		errorMsg := fmt.Sprintf("error: Response code %v. Expecting 2XX.", strconv.Itoa(status))
+		return status, errors.New(errorMsg)
+	}
+
+	return status, err
+}

--- a/syntheticsclientv2/get_apicheckv2.go
+++ b/syntheticsclientv2/get_apicheckv2.go
@@ -1,0 +1,51 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func parseApiCheckV2Response(response string) (*ApiCheckV2Response, error) {
+	// Parse the response and return the check object
+	var check ApiCheckV2Response
+	err := json.Unmarshal([]byte(response), &check)
+	if err != nil {
+		return nil, err
+	}
+
+	return &check, err
+}
+
+func (c Client) GetApiCheckV2(id int) (*ApiCheckV2Response, *RequestDetails, error) {
+
+	details, err := c.makePublicAPICall("GET",
+		fmt.Sprintf("/tests/api/%d", id),
+		bytes.NewBufferString("{}"),
+		nil)
+
+	if err != nil {
+		return nil, details, err
+	}
+
+	check, err := parseApiCheckV2Response(details.ResponseBody)
+	if err != nil {
+		return check, details, err
+	}
+
+	return check, details, nil
+}

--- a/syntheticsclientv2/get_apicheckv2_test.go
+++ b/syntheticsclientv2/get_apicheckv2_test.go
@@ -1,0 +1,98 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var (
+	getApiCheckV2Body  = `{"test":{"id":489,"name":"Appinspect login API","active":true,"frequency":5,"scheduling_strategy":"round_robin","created_at":"2022-08-16T15:47:43.730Z","updated_at":"2022-08-16T15:47:43.741Z","location_ids":["aws-us-east-1"],"type":"api","device":{"id":1,"label":"Desktop","user_agent":"Mozilla/5.0 (X11; Linux x86_64; Splunk Synthetics) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36","viewport_width":1366,"viewport_height":768,"network_connection":{"description":"Standard Cable","upload_bandwidth":5000,"download_bandwidth":20000,"latency":28,"packet_loss":null}},"requests":[{"configuration":{"name":"Login","url":"https://api.splunk.com/2.0/rest/login/splunk","requestMethod":"GET","headers":{},"body":null},"setup":[],"validations":[]}]}}`
+	inputGetApiCheckV2 = verifyApiCheckV2Input(string(getApiCheckV2Body))
+)
+
+func TestGetApiCheckV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests/api/489", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		_, err := w.Write([]byte(getApiCheckV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	resp, _, err := testClient.GetApiCheckV2(489)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(resp.Test.ID, inputGetApiCheckV2.Test.ID) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.ID, inputGetApiCheckV2.Test.ID)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Name, inputGetApiCheckV2.Test.Name) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Name, inputGetApiCheckV2.Test.Name)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Type, inputGetApiCheckV2.Test.Type) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Type, inputGetApiCheckV2.Test.Type)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Frequency, inputGetApiCheckV2.Test.Frequency) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Frequency, inputGetApiCheckV2.Test.Frequency)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Active, inputGetApiCheckV2.Test.Active) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Active, inputGetApiCheckV2.Test.Active)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Createdat, inputGetApiCheckV2.Test.Createdat) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Createdat, inputGetApiCheckV2.Test.Createdat)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Updatedat, inputGetApiCheckV2.Test.Updatedat) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Updatedat, inputGetApiCheckV2.Test.Updatedat)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Device, inputGetApiCheckV2.Test.Device) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Device, inputGetApiCheckV2.Test.Device)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Device.Viewportheight, inputGetApiCheckV2.Test.Device.Viewportheight) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Device.Viewportheight, inputGetApiCheckV2.Test.Device.Viewportheight)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Requests, inputGetApiCheckV2.Test.Requests) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Requests, inputGetApiCheckV2.Test.Requests)
+	}
+
+}
+
+func verifyApiCheckV2Input(stringInput string) *ApiCheckV2Response {
+	check := &ApiCheckV2Response{}
+	err := json.Unmarshal([]byte(stringInput), check)
+	if err != nil {
+		panic(err)
+	}
+	return check
+}

--- a/syntheticsclientv2/get_browsercheckv2.go
+++ b/syntheticsclientv2/get_browsercheckv2.go
@@ -1,0 +1,48 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func parseGetBrowserCheckV2Response(response string) (*BrowserCheckV2Response, error) {
+	// Parse the response and return the user object
+	var BrowserCheckV2 BrowserCheckV2Response
+	err := json.Unmarshal([]byte(response), &BrowserCheckV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &BrowserCheckV2, err
+}
+
+func (c Client) GetBrowserCheckV2(id int) (*BrowserCheckV2Response, *RequestDetails, error) {
+	details, err := c.makePublicAPICall("GET", fmt.Sprintf("/tests/browser/%d", id), bytes.NewBufferString("{}"), nil)
+
+	// Check for errors
+	if err != nil {
+		return nil, details, err
+	}
+
+	BrowserCheckV2, err := parseGetBrowserCheckV2Response(details.ResponseBody)
+	if err != nil {
+		return BrowserCheckV2, details, err
+	}
+
+	return BrowserCheckV2, details, nil
+}

--- a/syntheticsclientv2/get_browsercheckv2_test.go
+++ b/syntheticsclientv2/get_browsercheckv2_test.go
@@ -1,0 +1,98 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var (
+	getBrowserCheckV2Body  = `{"test":{"active":true,"advancedSettings":{"authentication":{"password":"password123","username":"myuser"},"cookies":[{"key":"qux","value":"qux","domain":"splunk.com","path":"/qux"}],"headers":[{"name":"Accept","value":"application/json","domain":"splunk.com"}],"verifyCertificates":true},"createdAt":"2022-09-14T14:35:37.801Z","device":{"id":1,"label":"iPhone","networkConnection":{"description":"Mobile LTE","downloadBandwidth":12000,"latency":70,"packetLoss":0,"uploadBandwidth":12000},"viewportHeight":844,"viewportWidth":375},"frequency":5,"id":1,"locationIds":["na-us-virginia"],"name":"My Test","schedulingStrategy":"round_robin","transactions":[{"name":"Example transaction","steps":[{"name":"element step","selector":".main","selectorType":"css","type":"click_element","waitForNav":true}]}],"type":"browser","updatedAt":"2022-09-14T14:35:38.099Z"}}`
+	inputGetBrowserCheckV2 = verifyBrowserCheckV2Input(string(getBrowserCheckV2Body))
+)
+
+func TestGetBrowserCheckV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests/browser/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		_, err := w.Write([]byte(getBrowserCheckV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	resp, _, err := testClient.GetBrowserCheckV2(1)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(resp.Test.ID, inputGetBrowserCheckV2.Test.ID) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.ID, inputGetBrowserCheckV2.Test.ID)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Name, inputGetBrowserCheckV2.Test.Name) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Name, inputGetBrowserCheckV2.Test.Name)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Type, inputGetBrowserCheckV2.Test.Type) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Type, inputGetBrowserCheckV2.Test.Type)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Frequency, inputGetBrowserCheckV2.Test.Frequency) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Frequency, inputGetBrowserCheckV2.Test.Frequency)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Active, inputGetBrowserCheckV2.Test.Active) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Active, inputGetBrowserCheckV2.Test.Active)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Createdat, inputGetBrowserCheckV2.Test.Createdat) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Createdat, inputGetBrowserCheckV2.Test.Createdat)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Updatedat, inputGetBrowserCheckV2.Test.Updatedat) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Updatedat, inputGetBrowserCheckV2.Test.Updatedat)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Device, inputGetBrowserCheckV2.Test.Device) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Device, inputGetBrowserCheckV2.Test.Device)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Advancedsettings, inputGetBrowserCheckV2.Test.Advancedsettings) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Advancedsettings, inputGetBrowserCheckV2.Test.Advancedsettings)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Transactions, inputGetBrowserCheckV2.Test.Transactions) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Transactions, inputGetBrowserCheckV2.Test.Transactions)
+	}
+
+}
+
+func verifyBrowserCheckV2Input(stringInput string) *BrowserCheckV2Response {
+	check := &BrowserCheckV2Response{}
+	err := json.Unmarshal([]byte(stringInput), check)
+	if err != nil {
+		panic(err)
+	}
+	return check
+}

--- a/syntheticsclientv2/get_checksv2.go
+++ b/syntheticsclientv2/get_checksv2.go
@@ -1,0 +1,68 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func parseChecksV2Response(response string) (*ChecksV2Response, error) {
+	// Parse the response and return the check object
+	var checks ChecksV2Response
+	err := json.Unmarshal([]byte(response), &checks)
+	if err != nil {
+		return nil, err
+	}
+
+	return &checks, err
+}
+
+// GetChecks returns all checks
+func (c Client) GetChecksV2(params *GetChecksV2Options) (*ChecksV2Response, *RequestDetails, error) {
+	// Check for default params
+	if params.TestType == "" {
+		params.TestType = ""
+	}
+	if params.Search == "" {
+		params.Search = ""
+	}
+	if params.Page == 0 {
+		params.Page = int(1)
+	}
+	if params.PerPage == 0 {
+		params.PerPage = int(50)
+	}
+
+	// Make the request
+	details, err := c.makePublicAPICall(
+		"GET",
+		fmt.Sprintf("/tests?testType=%s&page=%d&perPage=%d&orderBy=%s&search=%s", params.TestType, params.Page, params.PerPage, params.OrderBy, params.Search),
+		bytes.NewBufferString("{}"),
+		nil)
+
+	// Check for errors
+	if err != nil {
+		return nil, details, err
+	}
+
+	check, err := parseChecksV2Response(details.ResponseBody)
+	if err != nil {
+		return check, details, err
+	}
+
+	return check, details, nil
+}

--- a/syntheticsclientv2/get_checksv2_test.go
+++ b/syntheticsclientv2/get_checksv2_test.go
@@ -1,0 +1,69 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var (
+	getChecksV2Body   = `{"testType":"","page":1,"perPage":50,"search":"","orderBy":"id"}`
+	inputGetChecksV2  = verifyChecksV2Input(string(getChecksV2Body))
+	getChecksV2Output = `{"tests":[{"id":482,"name":"Test of Splunk.com","active":true,"frequency":5,"scheduling_strategy":"round_robin","created_at":"2022-08-15T16:05:25.815Z","updated_at":"2022-09-29T19:13:13.853Z","location_ids":["aws-us-east-1"],"type":"browser"},{"id":489,"name":"Appinspect login API","active":true,"frequency":5,"scheduling_strategy":"round_robin","created_at":"2022-08-16T15:47:43.730Z","updated_at":"2022-08-16T15:47:43.741Z","location_ids":["aws-us-east-1"],"type":"api"},{"id":490,"name":"Arch Linux Packages","active":true,"frequency":10,"scheduling_strategy":"round_robin","created_at":"2022-08-16T16:48:42.119Z","updated_at":"2022-08-16T16:48:42.131Z","location_ids":["aws-us-east-1"],"type":"http"},{"id":492,"name":"Test of Splunkbase","active":true,"frequency":5,"scheduling_strategy":"round_robin","created_at":"2022-08-16T19:35:54.014Z","updated_at":"2022-09-29T19:13:13.907Z","location_ids":["aws-us-east-1"],"type":"browser"},{"id":493,"name":"Brewery API","active":true,"frequency":5,"scheduling_strategy":"round_robin","created_at":"2022-08-16T19:44:15.626Z","updated_at":"2022-08-16T19:44:15.635Z","location_ids":["aws-us-east-1"],"type":"api"},{"id":495,"name":"Multi-step test of legacy Splunkbase","active":true,"frequency":5,"scheduling_strategy":"round_robin","created_at":"2022-08-17T01:24:44.579Z","updated_at":"2022-09-29T19:13:13.203Z","location_ids":["aws-us-east-1"],"type":"browser"},{"id":496,"name":"Multi-step Test of new Splunkbase","active":true,"frequency":5,"scheduling_strategy":"round_robin","created_at":"2022-08-17T01:33:27.771Z","updated_at":"2022-09-29T19:13:13.997Z","location_ids":["aws-us-east-1"],"type":"browser"},{"id":935,"name":"This test does test stuff","active":true,"frequency":30,"scheduling_strategy":"round_robin","created_at":"2022-10-26T14:48:36.026Z","updated_at":"2022-10-26T14:48:36.037Z","location_ids":["aws-us-east-1"],"type":"api"},{"id":1116,"name":"boop-test","active":true,"frequency":5,"scheduling_strategy":"round_robin","created_at":"2022-11-16T19:18:59.603Z","updated_at":"2022-11-16T19:20:58.911Z","location_ids":["aws-us-east-1","aws-ap-northeast-1"],"type":"api"},{"id":1128,"name":"boopbeep","active":true,"frequency":5,"scheduling_strategy":"round_robin","created_at":"2022-11-17T14:19:49.564Z","updated_at":"2022-11-17T14:19:49.571Z","location_ids":["aws-us-east-1"],"type":"browser"}],"page":1,"per_page":50,"next_page_link":null,"total_count":10}`
+	output            = &ChecksV2Response{}
+)
+
+func TestGetChecksV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		_, err := w.Write([]byte(getChecksV2Output))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	err := json.Unmarshal([]byte(getChecksV2Output), output)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, _, err := testClient.GetChecksV2(inputGetChecksV2)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(resp.Tests, output.Tests) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Tests, output.Tests)
+	}
+
+}
+
+func verifyChecksV2Input(stringInput string) *GetChecksV2Options {
+	check := &GetChecksV2Options{}
+	err := json.Unmarshal([]byte(stringInput), check)
+	if err != nil {
+		panic(err)
+	}
+	return check
+}

--- a/syntheticsclientv2/get_httpcheckv2.go
+++ b/syntheticsclientv2/get_httpcheckv2.go
@@ -1,0 +1,48 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func parseGetHttpCheckV2Response(response string) (*HttpCheckV2Response, error) {
+	// Parse the response and return the user object
+	var HttpCheckV2 HttpCheckV2Response
+	err := json.Unmarshal([]byte(response), &HttpCheckV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &HttpCheckV2, err
+}
+
+func (c Client) GetHttpCheckV2(id int) (*HttpCheckV2Response, *RequestDetails, error) {
+	details, err := c.makePublicAPICall("GET", fmt.Sprintf("/tests/http/%d", id), bytes.NewBufferString("{}"), nil)
+
+	// Check for errors
+	if err != nil {
+		return nil, details, err
+	}
+
+	HttpCheckV2, err := parseGetHttpCheckV2Response(details.ResponseBody)
+	if err != nil {
+		return HttpCheckV2, details, err
+	}
+
+	return HttpCheckV2, details, nil
+}

--- a/syntheticsclientv2/get_httpcheckv2_test.go
+++ b/syntheticsclientv2/get_httpcheckv2_test.go
@@ -1,0 +1,110 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var (
+	getHttpCheckV2Body  = `{"test":{"active":true,"advancedSettings":{"authentication":{"password":"password123","username":"myuser"},"cookies":[{"key":"qux","value":"qux","domain":"splunk.com","path":"/qux"}],"headers":[{"name":"Accept","value":"application/json","domain":"splunk.com"}],"verifyCertificates":true},"createdAt":"2022-09-14T14:35:37.801Z","device":{"id":1,"label":"iPhone","networkConnection":{"description":"Mobile LTE","downloadBandwidth":12000,"latency":70,"packetLoss":0,"uploadBandwidth":12000},"viewportHeight":844,"viewportWidth":375},"frequency":5,"id":1,"locationIds":["na-us-virginia"],"name":"My Test","schedulingStrategy":"round_robin","transactions":[{"name":"Example transaction","steps":[{"name":"element step","selector":".main","selectorType":"css","type":"click_element","waitForNav":true}]}],"type":"browser","updatedAt":"2022-09-14T14:35:38.099Z"}}`
+	inputGetHttpCheckV2 = verifyHttpCheckV2Input(string(getHttpCheckV2Body))
+)
+
+func TestGetHttpCheckV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests/http/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		_, err := w.Write([]byte(getHttpCheckV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	resp, _, err := testClient.GetHttpCheckV2(1)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(resp.Test.ID, inputGetHttpCheckV2.Test.ID) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.ID, inputGetHttpCheckV2.Test.ID)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Name, inputGetHttpCheckV2.Test.Name) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Name, inputGetHttpCheckV2.Test.Name)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Type, inputGetHttpCheckV2.Test.Type) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Type, inputGetHttpCheckV2.Test.Type)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Frequency, inputGetHttpCheckV2.Test.Frequency) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Frequency, inputGetHttpCheckV2.Test.Frequency)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Active, inputGetHttpCheckV2.Test.Active) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Active, inputGetHttpCheckV2.Test.Active)
+	}
+
+	if !reflect.DeepEqual(resp.Test.HttpHeaders, inputGetHttpCheckV2.Test.HttpHeaders) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.HttpHeaders, inputGetHttpCheckV2.Test.HttpHeaders)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Body, inputGetHttpCheckV2.Test.Body) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Body, inputGetHttpCheckV2.Test.Body)
+	}
+
+	if !reflect.DeepEqual(resp.Test.URL, inputGetHttpCheckV2.Test.URL) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.URL, inputGetHttpCheckV2.Test.URL)
+	}
+
+	if !reflect.DeepEqual(resp.Test.SchedulingStrategy, inputGetHttpCheckV2.Test.SchedulingStrategy) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.SchedulingStrategy, inputGetHttpCheckV2.Test.SchedulingStrategy)
+	}
+
+	if !reflect.DeepEqual(resp.Test.RequestMethod, inputGetHttpCheckV2.Test.RequestMethod) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.RequestMethod, inputGetHttpCheckV2.Test.RequestMethod)
+	}
+
+	if !reflect.DeepEqual(resp.Test.LocationIds, inputGetHttpCheckV2.Test.LocationIds) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.LocationIds, inputGetHttpCheckV2.Test.LocationIds)
+	}
+
+	if !reflect.DeepEqual(resp.Test.UpdatedAt, inputGetHttpCheckV2.Test.UpdatedAt) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.UpdatedAt, inputGetHttpCheckV2.Test.UpdatedAt)
+	}
+
+	if !reflect.DeepEqual(resp.Test.CreatedAt, inputGetHttpCheckV2.Test.CreatedAt) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.CreatedAt, inputGetHttpCheckV2.Test.CreatedAt)
+	}
+
+}
+
+func verifyHttpCheckV2Input(stringInput string) *HttpCheckV2Response {
+	check := &HttpCheckV2Response{}
+	err := json.Unmarshal([]byte(stringInput), check)
+	if err != nil {
+		panic(err)
+	}
+	return check
+}

--- a/syntheticsclientv2/get_portcheckv2.go
+++ b/syntheticsclientv2/get_portcheckv2.go
@@ -1,0 +1,48 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func parseGetPortCheckV2Response(response string) (*PortCheckV2Response, error) {
+	// Parse the response and return the user object
+	var PortCheckV2 PortCheckV2Response
+	err := json.Unmarshal([]byte(response), &PortCheckV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PortCheckV2, err
+}
+
+func (c Client) GetPortCheckV2(id int) (*PortCheckV2Response, *RequestDetails, error) {
+	details, err := c.makePublicAPICall("GET", fmt.Sprintf("/tests/port/%d", id), bytes.NewBufferString("{}"), nil)
+
+	// Check for errors
+	if err != nil {
+		return nil, details, err
+	}
+
+	PortCheckV2, err := parseGetPortCheckV2Response(details.ResponseBody)
+	if err != nil {
+		return PortCheckV2, details, err
+	}
+
+	return PortCheckV2, details, nil
+}

--- a/syntheticsclientv2/get_portcheckv2_test.go
+++ b/syntheticsclientv2/get_portcheckv2_test.go
@@ -1,0 +1,98 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var (
+	getPortCheckV2Body  = `{"test":{"id":1647,"name":"splunk - port 443","active":true,"frequency":10,"scheduling_strategy":"round_robin","created_at":"2022-11-21T15:38:54.546Z","updated_at":"2022-11-21T15:38:54.554Z","location_ids":["aws-us-east-1"],"type":"port","protocol":"tcp","host":"www.splunk.com","port":443}}`
+	inputGetPortCheckV2 = verifyPortCheckV2Input(string(getPortCheckV2Body))
+)
+
+func TestGetPortCheckV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests/port/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		_, err := w.Write([]byte(getPortCheckV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	resp, _, err := testClient.GetPortCheckV2(1)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(resp.Test.ID, inputGetPortCheckV2.Test.ID) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.ID, inputGetPortCheckV2.Test.ID)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Name, inputGetPortCheckV2.Test.Name) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Name, inputGetPortCheckV2.Test.Name)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Type, inputGetPortCheckV2.Test.Type) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Type, inputGetPortCheckV2.Test.Type)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Frequency, inputGetPortCheckV2.Test.Frequency) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Frequency, inputGetPortCheckV2.Test.Frequency)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Active, inputGetPortCheckV2.Test.Active) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Active, inputGetPortCheckV2.Test.Active)
+	}
+
+	if !reflect.DeepEqual(resp.Test.CreatedAt, inputGetPortCheckV2.Test.CreatedAt) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.CreatedAt, inputGetPortCheckV2.Test.CreatedAt)
+	}
+
+	if !reflect.DeepEqual(resp.Test.UpdatedAt, inputGetPortCheckV2.Test.UpdatedAt) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.UpdatedAt, inputGetPortCheckV2.Test.UpdatedAt)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Protocol, inputGetPortCheckV2.Test.Protocol) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Protocol, inputGetPortCheckV2.Test.Protocol)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Host, inputGetPortCheckV2.Test.Host) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Host, inputGetPortCheckV2.Test.Host)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Port, inputGetPortCheckV2.Test.Port) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Port, inputGetPortCheckV2.Test.Port)
+	}
+
+}
+
+func verifyPortCheckV2Input(stringInput string) *PortCheckV2Response {
+	check := &PortCheckV2Response{}
+	err := json.Unmarshal([]byte(stringInput), check)
+	if err != nil {
+		panic(err)
+	}
+	return check
+}

--- a/syntheticsclientv2/get_variablev2.go
+++ b/syntheticsclientv2/get_variablev2.go
@@ -1,0 +1,51 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func parseVariableV2Response(response string) (*VariableV2Response, error) {
+	// Parse the response and return the check object
+	var check VariableV2Response
+	err := json.Unmarshal([]byte(response), &check)
+	if err != nil {
+		return nil, err
+	}
+
+	return &check, err
+}
+
+func (c Client) GetVariableV2(id int) (*VariableV2Response, *RequestDetails, error) {
+
+	details, err := c.makePublicAPICall("GET",
+		fmt.Sprintf("/variables/%d", id),
+		bytes.NewBufferString("{}"),
+		nil)
+
+	if err != nil {
+		return nil, details, err
+	}
+
+	check, err := parseVariableV2Response(details.ResponseBody)
+	if err != nil {
+		return check, details, err
+	}
+
+	return check, details, nil
+}

--- a/syntheticsclientv2/get_variablev2_test.go
+++ b/syntheticsclientv2/get_variablev2_test.go
@@ -1,0 +1,86 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var (
+	getVariableV2Body  = `{"variable":{"id":1,"name":"beep-var","description":"","value":"<REDACTED>","secret":true,"created_at":"2022-11-16T14:55:09.480Z","updated_at":"2022-11-16T14:55:09.480Z"}}`
+	inputGetVariableV2 = verifyVariableV2Input(string(getVariableV2Body))
+)
+
+func TestGetVariableV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/variables/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		_, err := w.Write([]byte(getVariableV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	resp, _, err := testClient.GetVariableV2(1)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(resp.Variable.ID, inputGetVariableV2.Variable.ID) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Variable.ID, inputGetVariableV2.Variable.ID)
+	}
+
+	if !reflect.DeepEqual(resp.Variable.Name, inputGetVariableV2.Variable.Name) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Variable.Name, inputGetVariableV2.Variable.Name)
+	}
+
+	if !reflect.DeepEqual(resp.Variable.Description, inputGetVariableV2.Variable.Description) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Variable.Description, inputGetVariableV2.Variable.Description)
+	}
+
+	if !reflect.DeepEqual(resp.Variable.Value, inputGetVariableV2.Variable.Value) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Variable.Value, inputGetVariableV2.Variable.Value)
+	}
+
+	if !reflect.DeepEqual(resp.Variable.Secret, inputGetVariableV2.Variable.Secret) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Variable.Secret, inputGetVariableV2.Variable.Secret)
+	}
+
+	if !reflect.DeepEqual(resp.Variable.Createdat, inputGetVariableV2.Variable.Createdat) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Variable.Createdat, inputGetVariableV2.Variable.Createdat)
+	}
+
+	if !reflect.DeepEqual(resp.Variable.Updatedat, inputGetVariableV2.Variable.Updatedat) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Variable.Updatedat, inputGetVariableV2.Variable.Updatedat)
+	}
+
+}
+
+func verifyVariableV2Input(stringInput string) *VariableV2Response {
+	check := &VariableV2Response{}
+	err := json.Unmarshal([]byte(stringInput), check)
+	if err != nil {
+		panic(err)
+	}
+	return check
+}

--- a/syntheticsclientv2/integration_test.go
+++ b/syntheticsclientv2/integration_test.go
@@ -1,0 +1,392 @@
+//go:build integration
+// +build integration
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+)
+
+var (
+	token                    = os.Getenv("API_ACCESS_TOKEN")
+	realm                    = os.Getenv("REALM")
+	getChecksV2Body          = `{"testType":"","page":1,"perPage":50,"search":"","orderBy":"id"}`
+	inputGetChecksV2         = GetChecksV2Options{}
+	createVariableV2Body     = `{"variable":{"description":"My super awesome test variable","name":"food","secret":false,"value":"bar"}}`
+	inputVariableV2Data      = VariableV2Input{}
+	createHttpCheckV2Body    = `{"test":{"name":"morebeeps-test","type":"http","url":"https://www.splunk.com","location_ids":["aws-us-east-1"],"frequency":10,"scheduling_strategy":"round_robin","active":true,"request_method":"GET","body":null,"headers":[{"name":"boop","value":"beep"}]}}`
+	inputHttpCheckV2Data     = HttpCheckV2Input{}
+	createBrowserCheckV2Body = `{"test":{"name":"browser-beep-test","business_transactions":[{"name":"Synthetic transaction 1","steps":[{"name":"Go to URL","type":"go_to_url","url":"https://www.splunk.com","action":"go_to_url","wait_for_nav":true},{"name":"Nexter step","type":"click_element","selector_type":"id","wait_for_nav":false,"selector":"free-splunk-click-desktop"}]}],"urlProtocol":"https://","startUrl":"www.splunk.com","location_ids":["aws-us-east-1"],"device_id":1,"frequency":5,"scheduling_strategy":"round_robin","active":true,"advanced_settings":{"verify_certificates":true,"authentication":{"username":"boopuser","password":"{{env.beep-var}}"},"headers":[{"name":"batman","value":"Agentoz","domain":"www.batmansagent.com"}],"cookies":[{"key":"super","value":"duper","domain":"www.batmansagent.com","path":"/boom/goes/beep"}]}}}`
+	inputBrowserCheckV2Data  = BrowserCheckV2Input{}
+	createPortCheckV2Body    = `{"test":{"name":"splunk - port 443","type":"port","url":"","port":443,"protocol":"tcp","host":"www.splunk.com","location_ids":["aws-us-east-1"],"frequency":10,"scheduling_strategy":"round_robin","active":true}}`
+	inputPortCheckV2Data     = PortCheckV2Input{}
+	createApiV2Body          = `{"test":{"active":true,"device_id":1,"frequency":5,"location_ids":["aws-us-east-1"],"name":"boop-test","scheduling_strategy":"round_robin","requests":[{"configuration":{"name":"Get-Test","requestMethod":"GET","url":"https://api.us1.signalfx.com/v2/synthetics/tests/api/489","headers":{"X-SF-TOKEN":"jinglebellsbatmanshells", "beep":"boop"},"body":null},"setup":[{"name":"Extract from response body","type":"extract_json","source":"{{response.body}}","extractor":"$.requests","variable":"custom-varz"}],"validations":[{"name":"Assert response code equals 200","type":"assert_numeric","actual":"{{response.code}}","expected":"200","comparator":"equals"}]}]}}`
+	inputApiCheckV2Data      = ApiCheckV2Input{}
+)
+
+// You will need to fill in values for the get and delete tests
+// as the check ids will vary from organization to organization
+
+func TestLiveGetChecksV2(t *testing.T) {
+
+	//Create your client with the token
+	c := NewClient(token, realm)
+
+	err := json.Unmarshal([]byte(getChecksV2Body), &inputGetChecksV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Make the request with your check settings and print result
+	res, _, err := c.GetChecksV2(&inputGetChecksV2)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		JsonPrint(res)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestLiveCreateVariableV2(t *testing.T) {
+
+	err := json.Unmarshal([]byte(createVariableV2Body), &inputVariableV2Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Create your client with the token
+	c := NewClient(token, realm)
+
+	fmt.Println(inputVariableV2Data)
+
+	// Make the request with your check settings and print result
+	res, reqDetail, err := c.CreateVariableV2(&inputVariableV2Data)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println(reqDetail)
+		JsonPrint(res)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestLiveGetVariableV2(t *testing.T) {
+
+	//Create your client with the token
+	c := NewClient(token, realm)
+
+	// Make the request with your check settings and print result
+	res, _, err := c.GetVariableV2(246)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		JsonPrint(res)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestLiveDeleteVariableV2(t *testing.T) {
+
+	//Create your client with the token
+	c := NewClient(token, realm)
+
+	// Make the request with your check settings and print result
+	res, err := c.DeleteVariableV2(254)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		JsonPrint(res)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestLiveCreateHttpCheckV2(t *testing.T) {
+
+	err := json.Unmarshal([]byte(createHttpCheckV2Body), &inputHttpCheckV2Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Create your client with the token
+	c := NewClient(token, realm)
+
+	fmt.Println(inputHttpCheckV2Data)
+
+	// Make the request with your check settings and print result
+	res, reqDetail, err := c.CreateHttpCheckV2(&inputHttpCheckV2Data)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println(reqDetail)
+		JsonPrint(res)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestLiveGetHttpCheckV2(t *testing.T) {
+
+	//Create your client with the token
+	c := NewClient(token, realm)
+
+	// Make the request with your check settings and print result
+	res, _, err := c.GetHttpCheckV2(1528)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		JsonPrint(res)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestLiveDeleteHttpCheckV2(t *testing.T) {
+
+	//Create your client with the token
+	c := NewClient(token, realm)
+
+	// Make the request with your check settings and print result
+	res, err := c.DeleteHttpCheckV2(1528)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		JsonPrint(res)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestLiveCreateBrowserCheckV2(t *testing.T) {
+
+	err := json.Unmarshal([]byte(createBrowserCheckV2Body), &inputBrowserCheckV2Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Create your client with the token
+	c := NewClient(token, realm)
+
+	fmt.Println(inputBrowserCheckV2Data)
+
+	// Make the request with your check settings and print result
+	res, reqDetail, err := c.CreateBrowserCheckV2(&inputBrowserCheckV2Data)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println(reqDetail)
+		JsonPrint(res)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestLiveGetBrowserCheckV2(t *testing.T) {
+
+	//Create your client with the token
+	c := NewClient(token, realm)
+
+	// Make the request with your check settings and print result
+	res, _, err := c.GetBrowserCheckV2(495)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		JsonPrint(res)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestLiveDeleteBrowserCheckV2(t *testing.T) {
+
+	//Create your client with the token
+	c := NewClient(token, realm)
+
+	// Make the request with your check settings and print result
+	res, err := c.DeleteBrowserCheckV2(1115)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		JsonPrint(res)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestLiveCreateApiCheckV2(t *testing.T) {
+
+	err := json.Unmarshal([]byte(createApiV2Body), &inputApiCheckV2Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Create your client with the token
+	c := NewClient(token, realm)
+
+	// Make the request with your check settings and print result
+	res, reqDetail, err := c.CreateApiCheckV2(&inputApiCheckV2Data)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println(reqDetail)
+		JsonPrint(res)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestLiveGetApiCheckV2(t *testing.T) {
+
+	//Create your client with the token
+	c := NewClient(token, realm)
+
+	// Make the request with your check settings and print result
+	res, _, err := c.GetApiCheckV2(489)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		JsonPrint(res)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestLiveDeleteApiCheckV2(t *testing.T) {
+
+	//Create your client with the token
+	c := NewClient(token, realm)
+
+	// Make the request with your check settings and print result
+	res, err := c.DeleteApiCheckV2(1093)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		JsonPrint(res)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestLiveCreatePortCheckV2(t *testing.T) {
+
+	err := json.Unmarshal([]byte(createPortCheckV2Body), &inputPortCheckV2Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Create your client with the token
+	c := NewClient(token, realm)
+
+	fmt.Println(inputPortCheckV2Data)
+
+	// Make the request with your check settings and print result
+	res, reqDetail, err := c.CreatePortCheckV2(&inputPortCheckV2Data)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println(reqDetail)
+		JsonPrint(res)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestLiveGetPortCheckV2(t *testing.T) {
+
+	//Create your client with the token
+	c := NewClient(token, realm)
+
+	// Make the request with your check settings and print result
+	res, _, err := c.GetPortCheckV2(1647)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		JsonPrint(res)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestLiveDeletePortCheckV2(t *testing.T) {
+
+	//Create your client with the token
+	c := NewClient(token, realm)
+
+	// Make the request with your check settings and print result
+	res, err := c.DeletePortCheckV2(1649)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		JsonPrint(res)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}

--- a/syntheticsclientv2/synthetics.go
+++ b/syntheticsclientv2/synthetics.go
@@ -1,0 +1,156 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httputil"
+	"time"
+)
+
+type Client struct {
+	publicBaseURL string
+	apiKey        string
+	realm         string
+	httpClient    http.Client
+}
+
+type ClientArgs struct {
+	timeoutSeconds int
+	publicBaseUrl  string
+}
+
+type RequestDetails struct {
+	StatusCode   int
+	ResponseBody string
+	RequestBody  string
+	RawResponse  *http.Response
+	RawRequest   *http.Request
+}
+
+type errorResponse struct {
+	Status  string `json:"status,omitempty"`
+	Error   string `json:"error,omitempty"`
+	Result  string `json:"result,omitempty"`
+	Message string `json:"message,omitempty"`
+	Errors  Errors `json:"errors,omitempty"`
+}
+
+func (c Client) String() string {
+	return fmt.Sprintf("Splunk Synthetics Client: URL: %s ", c.publicBaseURL)
+}
+
+func (c Client) makePublicAPICall(method string, endpoint string, requestBody io.Reader, queryParams map[string]string) (*RequestDetails, error) {
+	details := RequestDetails{}
+	// Create the request
+	req, err := http.NewRequest(method, c.publicBaseURL+endpoint, requestBody)
+	if err != nil {
+		return &details, err
+	}
+
+	// Set the auth headers needed for the public api
+	req.Header.Set("X-SF-TOKEN", c.apiKey)
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	// Set the query params
+	q := req.URL.Query()
+	for key, value := range queryParams {
+		q.Add(key, value)
+	}
+	req.URL.RawQuery = q.Encode()
+
+	// Add the request to the details
+	details.RawRequest = req
+	requestDump, err := httputil.DumpRequestOut(req, true)
+	if err != nil {
+		return &details, err
+	}
+	details.RequestBody = string(requestDump)
+	fmt.Println("************")
+	fmt.Println(details.RequestBody)
+	fmt.Println("************")
+
+	// Make the request
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return &details, err
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
+		var errRes errorResponse
+		if err = json.NewDecoder(resp.Body).Decode(&errRes); err == nil {
+			errorField, err2 := json.Marshal(errRes)
+			if err2 != nil {
+				return &details, fmt.Errorf("unknown issue while parsing API error response, status code: %d", resp.StatusCode)
+			}
+			return &details, errors.New("Status Code: " + resp.Status + "\n" + string(errorField))
+		}
+		return &details, fmt.Errorf("unknown error, status code: %d", resp.StatusCode)
+	}
+
+	responseBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return &details, err
+	}
+
+	details.StatusCode = resp.StatusCode
+	details.ResponseBody = string(responseBody)
+	details.RawResponse = resp
+
+	return &details, nil
+}
+
+func NewClient(apiKey string, realm string) *Client {
+	args := ClientArgs{timeoutSeconds: 30}
+	return NewConfigurableClient(apiKey, realm, args)
+}
+
+func NewConfigurableClient(apiKey string, realm string, args ClientArgs) *Client {
+	client := Client{
+		apiKey:     apiKey,
+		realm:      realm,
+		httpClient: http.Client{Timeout: time.Duration(args.timeoutSeconds) * time.Second},
+	}
+	if args.publicBaseUrl == "" {
+		client.publicBaseURL = "https://api." + realm + ".signalfx.com/v2/synthetics"
+	} else {
+		client.publicBaseURL = args.publicBaseUrl
+	}
+
+	return &client
+}
+
+// GetHTTPClient returns http client for the purpose of test
+func (c Client) GetHTTPClient() *http.Client {
+	return &c.httpClient
+}
+
+// Helper for tests and output
+func JsonPrint(data interface{}) {
+	var p []byte
+	p, err := json.Marshal(data)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Printf("%s \n", p)
+}

--- a/syntheticsclientv2/synthetics_test.go
+++ b/syntheticsclientv2/synthetics_test.go
@@ -1,0 +1,100 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+var (
+	// mux is the HTTP request multiplexer used with the test server.
+	testMux *http.ServeMux
+
+	testClient *Client
+
+	// server is a test HTTP server used to provide mock API responses.
+	testServer *httptest.Server
+)
+
+func setup() {
+	testMux = http.NewServeMux()
+	testServer = httptest.NewServer(testMux)
+
+	testClient = NewConfigurableClient("apiKey", "realm", ClientArgs{
+		publicBaseUrl: testServer.URL,
+	})
+	log.Printf("Client instantiated: %s", testClient.publicBaseURL)
+}
+
+func teardown() {
+	testServer.Close()
+}
+
+func testMethod(t *testing.T, r *http.Request, want string) {
+	if got := r.Method; got != want {
+		t.Errorf("Request method: %v, want %v", got, want)
+	}
+}
+
+func TestConfigurableClient(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux = http.NewServeMux()
+	testServer = httptest.NewServer(testMux)
+	args := ClientArgs{
+		timeoutSeconds: 30,
+		publicBaseUrl:  testServer.URL,
+	}
+
+	testConfigurableClient := NewConfigurableClient("snakedonut", "us0", args)
+	log.Printf("Client instantiated: %s", testServer.URL)
+	if testConfigurableClient.GetHTTPClient() == nil {
+		t.Errorf("http client is nil")
+	}
+	if testConfigurableClient.apiKey != "snakedonut" {
+		t.Errorf("returned \n\n%#v want \n\n%#v", testConfigurableClient.apiKey, "snakedonut")
+	}
+	if testConfigurableClient.realm != "us0" {
+		t.Errorf("returned \n\n%#v want \n\n%#v", testConfigurableClient.realm, "us0")
+	}
+}
+
+func TestConfigurableClientTimeout(t *testing.T) {
+	testMux = http.NewServeMux()
+	testServer = httptest.NewServer(testMux)
+
+	testMux.HandleFunc("/tests/browser/12", func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+	})
+
+	testConfigurableClient := NewConfigurableClient("apiKey", "realm", ClientArgs{
+		timeoutSeconds: 1,
+		publicBaseUrl:  testServer.URL,
+	})
+	log.Printf("Client instantiated: %s", testServer.URL)
+	_, _, err := testConfigurableClient.GetBrowserCheckV2(12)
+	if !strings.Contains(err.Error(), "context deadline exceeded (Client.Timeout exceeded while awaiting headers)") {
+		t.Errorf("expected to see timeout error, but saw: %s", err.Error())
+	}
+}

--- a/syntheticsclientv2/update_apicheckv2.go
+++ b/syntheticsclientv2/update_apicheckv2.go
@@ -1,0 +1,51 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func parseUpdateApiCheckV2Response(response string) (*ApiCheckV2Response, error) {
+	var updateApiCheckV2 ApiCheckV2Response
+	err := json.Unmarshal([]byte(response), &updateApiCheckV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &updateApiCheckV2, err
+}
+
+func (c Client) UpdateApiCheckV2(id int, ApiCheckV2Details *ApiCheckV2Input) (*ApiCheckV2Response, *RequestDetails, error) {
+
+	body, err := json.Marshal(ApiCheckV2Details)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	requestDetails, err := c.makePublicAPICall("PUT", fmt.Sprintf("/tests/api/%d", id), bytes.NewBuffer(body), nil)
+	if err != nil {
+		return nil, requestDetails, err
+	}
+
+	updateApiCheckV2, err := parseUpdateApiCheckV2Response(requestDetails.ResponseBody)
+	if err != nil {
+		return updateApiCheckV2, requestDetails, err
+	}
+
+	return updateApiCheckV2, requestDetails, nil
+}

--- a/syntheticsclientv2/update_apicheckv2_test.go
+++ b/syntheticsclientv2/update_apicheckv2_test.go
@@ -1,0 +1,81 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var (
+	updateApiCheckV2Body  = `{"test":{"active":true,"device_id":4,"frequency":5,"location_ids":["aws-us-east-1","aws-ap-northeast-1"],"name":"boop-test","scheduling_strategy":"round_robin","requests":[{"configuration":{"name":"Get-Test","requestMethod":"GET","url":"https://api.us1.signalfx.com/v2/synthetics/tests/api/489","headers":{"beep":"boop","X-SF-TOKEN":"jinglebellsbatmanshells"},"body":null},"setup":[{"name":"Extract from response body","type":"extract_json","source":"{{response.body}}","extractor":"$.requests","variable":"custom-varz"}],"validations":[{"name":"Assert response code equals 200","type":"assert_numeric","actual":"{{response.code}}","expected":"200","comparator":"equals"}]}]}}`
+	inputApiCheckV2Update = ApiCheckV2Input{}
+)
+
+func TestUpdateApiCheckV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests/api/10", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		_, err := w.Write([]byte(updateApiCheckV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	err := json.Unmarshal([]byte(updateApiCheckV2Body), &inputApiCheckV2Update)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, _, err := testClient.UpdateApiCheckV2(10, &inputApiCheckV2Update)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(resp)
+
+	if !reflect.DeepEqual(resp.Test.Name, inputApiCheckV2Update.Test.Name) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Name, inputApiCheckV2Update.Test.Name)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Active, inputApiCheckV2Update.Test.Active) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Active, inputApiCheckV2Update.Test.Active)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Locationids, inputApiCheckV2Update.Test.Locationids) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Locationids, inputApiCheckV2Update.Test.Locationids)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Frequency, inputApiCheckV2Update.Test.Frequency) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Frequency, inputApiCheckV2Update.Test.Frequency)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Requests, inputApiCheckV2Update.Test.Requests) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Requests, inputApiCheckV2Update.Test.Requests)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Schedulingstrategy, inputApiCheckV2Update.Test.Schedulingstrategy) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Schedulingstrategy, inputApiCheckV2Update.Test.Schedulingstrategy)
+	}
+
+}

--- a/syntheticsclientv2/update_browsercheckv2.go
+++ b/syntheticsclientv2/update_browsercheckv2.go
@@ -1,0 +1,51 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func parseUpdateBrowserCheckV2Response(response string) (*BrowserCheckV2Response, error) {
+	var updateBrowserCheckV2 BrowserCheckV2Response
+	err := json.Unmarshal([]byte(response), &updateBrowserCheckV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &updateBrowserCheckV2, err
+}
+
+func (c Client) UpdateBrowserCheckV2(id int, BrowserCheckV2Details *BrowserCheckV2Input) (*BrowserCheckV2Response, *RequestDetails, error) {
+
+	body, err := json.Marshal(BrowserCheckV2Details)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	requestDetails, err := c.makePublicAPICall("PUT", fmt.Sprintf("/tests/browser/%d", id), bytes.NewBuffer(body), nil)
+	if err != nil {
+		return nil, requestDetails, err
+	}
+
+	updateBrowserCheckV2, err := parseUpdateBrowserCheckV2Response(requestDetails.ResponseBody)
+	if err != nil {
+		return updateBrowserCheckV2, requestDetails, err
+	}
+
+	return updateBrowserCheckV2, requestDetails, nil
+}

--- a/syntheticsclientv2/update_browsercheckv2_test.go
+++ b/syntheticsclientv2/update_browsercheckv2_test.go
@@ -1,0 +1,61 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var (
+	updateBrowserCheckV2Body  = `{"test":{"name":"browser-beep-test","business_transactions":[{"name":"Synthetic transaction 1","steps":[{"name":"Go to URL","type":"go_to_url","url":"https://www.splunk.com","action":"go_to_url","options":{"url":"https://www.splunk.com"},"wait_for_nav":true},{"name":"Nexter step","type":"click_element","selector_type":"id","selector":"free-splunk-click-desktop","wait_for_nav":false}]}],"urlProtocol":"https://","startUrl":"www.splunk.com","location_ids":["aws-us-east-1"],"device_id":2,"frequency":5,"scheduling_strategy":"round_robin","active":true,"advanced_settings":{"authentication":{"username":"boopuser","password":"{{env.beep-var}}"},"cookies":[{"key":"super","value":"duper","domain":"www.batmansagent.com","path":"/boom/goes/beep"}],"headers":[{"name":"batman","value":"Agentoz","domain":"www.batmansagent.com"}],"host_overrides":[],"user_agent":"Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X; Splunk Synthetics) AppleWebKit/604.1.25 (KHTML, like Gecko) Version/11.0 Mobile/15A5304j Safari/604.1","verify_certificates":true}}}`
+	inputBrowserCheckV2Update = BrowserCheckV2Input{}
+)
+
+func TestUpdateBrowserCheckV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests/browser/10", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		_, err := w.Write([]byte(updateBrowserCheckV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	err := json.Unmarshal([]byte(updateBrowserCheckV2Body), &inputBrowserCheckV2Update)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, _, err := testClient.UpdateBrowserCheckV2(10, &inputBrowserCheckV2Update)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(resp)
+
+	if !reflect.DeepEqual(resp.Test.Name, inputBrowserCheckV2Update.Test.Name) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Name, inputBrowserCheckV2Update.Test.Name)
+	}
+
+}

--- a/syntheticsclientv2/update_httpcheckv2.go
+++ b/syntheticsclientv2/update_httpcheckv2.go
@@ -1,0 +1,51 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func parseUpdateHttpCheckV2Response(response string) (*HttpCheckV2Response, error) {
+	var updateHttpCheckV2 HttpCheckV2Response
+	err := json.Unmarshal([]byte(response), &updateHttpCheckV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &updateHttpCheckV2, err
+}
+
+func (c Client) UpdateHttpCheckV2(id int, HttpCheckV2Details *HttpCheckV2Input) (*HttpCheckV2Response, *RequestDetails, error) {
+
+	body, err := json.Marshal(HttpCheckV2Details)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	requestDetails, err := c.makePublicAPICall("PUT", fmt.Sprintf("/tests/http/%d", id), bytes.NewBuffer(body), nil)
+	if err != nil {
+		return nil, requestDetails, err
+	}
+
+	updateHttpCheckV2, err := parseUpdateHttpCheckV2Response(requestDetails.ResponseBody)
+	if err != nil {
+		return updateHttpCheckV2, requestDetails, err
+	}
+
+	return updateHttpCheckV2, requestDetails, nil
+}

--- a/syntheticsclientv2/update_httpcheckv2_test.go
+++ b/syntheticsclientv2/update_httpcheckv2_test.go
@@ -1,0 +1,61 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var (
+	updateHttpCheckV2Body  = `{"test":{"name":"morebeeps-test","type":"http","url":"https://www.splunk.com","location_ids":["aws-us-east-1"],"frequency":10,"scheduling_strategy":"round_robin","active":true,"request_method":"GET","body":null,"headers":[{"name":"boop","value":"beep"}]}}`
+	inputHttpCheckV2Update = HttpCheckV2Input{}
+)
+
+func TestUpdateHttpCheckV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests/http/10", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		_, err := w.Write([]byte(updateHttpCheckV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	err := json.Unmarshal([]byte(updateHttpCheckV2Body), &inputHttpCheckV2Update)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, _, err := testClient.UpdateHttpCheckV2(10, &inputHttpCheckV2Update)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(resp)
+
+	if !reflect.DeepEqual(resp.Test.Name, inputHttpCheckV2Update.Test.Name) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Name, inputHttpCheckV2Update.Test.Name)
+	}
+
+}

--- a/syntheticsclientv2/update_portcheckv2.go
+++ b/syntheticsclientv2/update_portcheckv2.go
@@ -1,0 +1,51 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func parseUpdatePortCheckV2Response(response string) (*PortCheckV2Response, error) {
+	var updatePortCheckV2 PortCheckV2Response
+	err := json.Unmarshal([]byte(response), &updatePortCheckV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &updatePortCheckV2, err
+}
+
+func (c Client) UpdatePortCheckV2(id int, PortCheckV2Details *PortCheckV2Input) (*PortCheckV2Response, *RequestDetails, error) {
+
+	body, err := json.Marshal(PortCheckV2Details)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	requestDetails, err := c.makePublicAPICall("PUT", fmt.Sprintf("/tests/port/%d", id), bytes.NewBuffer(body), nil)
+	if err != nil {
+		return nil, requestDetails, err
+	}
+
+	updatePortCheckV2, err := parseUpdatePortCheckV2Response(requestDetails.ResponseBody)
+	if err != nil {
+		return updatePortCheckV2, requestDetails, err
+	}
+
+	return updatePortCheckV2, requestDetails, nil
+}

--- a/syntheticsclientv2/update_portcheckv2_test.go
+++ b/syntheticsclientv2/update_portcheckv2_test.go
@@ -1,0 +1,61 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var (
+	updatePortCheckV2Body  = `{"test":{"name":"splunk - port 443","type":"port","url":"","port":80,"protocol":"tcp","host":"www.splunk.com","location_ids":["aws-us-east-1"],"frequency":10,"scheduling_strategy":"round_robin","active":true}}`
+	inputPortCheckV2Update = PortCheckV2Input{}
+)
+
+func TestUpdatePortCheckV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests/port/1650", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		_, err := w.Write([]byte(updatePortCheckV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	err := json.Unmarshal([]byte(updatePortCheckV2Body), &inputPortCheckV2Update)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, _, err := testClient.UpdatePortCheckV2(1650, &inputPortCheckV2Update)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(resp)
+
+	if !reflect.DeepEqual(resp.Test.Name, inputPortCheckV2Update.Test.Name) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Name, inputPortCheckV2Update.Test.Name)
+	}
+
+}

--- a/syntheticsclientv2/update_variablesv2_test.go
+++ b/syntheticsclientv2/update_variablesv2_test.go
@@ -1,0 +1,73 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var (
+	updateVariableV2Body  = `{"variable":{"description":"My super awesome test variable","name":"foo2","secret":false,"value":"bar"}}`
+	inputVariableV2Update = VariableV2Input{}
+)
+
+func TestUpdateVariableV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/variables/10", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		_, err := w.Write([]byte(updateVariableV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	err := json.Unmarshal([]byte(updateVariableV2Body), &inputVariableV2Update)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, _, err := testClient.UpdateVariableV2(10, &inputVariableV2Update)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(resp)
+
+	if !reflect.DeepEqual(resp.Variable.Name, inputVariableV2Update.Variable.Name) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Variable.Name, inputVariableV2Update.Variable.Name)
+	}
+
+	if !reflect.DeepEqual(resp.Variable.Description, inputVariableV2Update.Variable.Description) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Variable.Description, inputVariableV2Update.Variable.Description)
+	}
+
+	if !reflect.DeepEqual(resp.Variable.Value, inputVariableV2Update.Variable.Value) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Variable.Value, inputVariableV2Update.Variable.Value)
+	}
+
+	if !reflect.DeepEqual(resp.Variable.Secret, inputVariableV2Update.Variable.Secret) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Variable.Secret, inputVariableV2Update.Variable.Secret)
+	}
+
+}

--- a/syntheticsclientv2/update_variablev2.go
+++ b/syntheticsclientv2/update_variablev2.go
@@ -1,0 +1,51 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func parseUpdateVariableV2Response(response string) (*VariableV2Response, error) {
+	var updateVariableV2 VariableV2Response
+	err := json.Unmarshal([]byte(response), &updateVariableV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &updateVariableV2, err
+}
+
+func (c Client) UpdateVariableV2(id int, VariableV2Details *VariableV2Input) (*VariableV2Response, *RequestDetails, error) {
+
+	body, err := json.Marshal(VariableV2Details)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	requestDetails, err := c.makePublicAPICall("PUT", fmt.Sprintf("/variables/%d", id), bytes.NewBuffer(body), nil)
+	if err != nil {
+		return nil, requestDetails, err
+	}
+
+	updateVariableV2, err := parseUpdateVariableV2Response(requestDetails.ResponseBody)
+	if err != nil {
+		return updateVariableV2, requestDetails, err
+	}
+
+	return updateVariableV2, requestDetails, nil
+}


### PR DESCRIPTION
Adds structs and code for V2 Synthetics API endpoints in Splunk Observability.
Example: https://dev.splunk.com/observability/reference/api/synthetics_api_tests/latest#endpoint-createapitest

Original package will have no changes and be deprecated but still available for Rigor Classic until Rigor Classic reaches end of life.

- Updated readme doc.
- Tested with new upcoming update to the terraform provider
- Includes integration tests that interact with the live API