### PR TITLE
Updates to fields, breaking pointer change for useragent

### DIFF
--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -28,12 +28,13 @@ type Networkconnection struct {
 }
 
 type Advancedsettings struct {
-	Authentication     *Authentication  `json:"authentication"`
-	Cookiesv2          []Cookiesv2      `json:"cookies"`
-	BrowserHeaders     []BrowserHeaders `json:"headers,omitempty"`
-	HostOverrides      []HostOverrides  `json:"hostOverrides,omitempty"`
-	UserAgent          string           `json:"userAgent,omitempty"`
-	Verifycertificates bool             `json:"verifyCertificates"`
+	Authentication            *Authentication  `json:"authentication"`
+	Cookiesv2                 []Cookiesv2      `json:"cookies"`
+	BrowserHeaders            []BrowserHeaders `json:"headers,omitempty"`
+	HostOverrides             []HostOverrides  `json:"hostOverrides,omitempty"`
+	UserAgent                 *string          `json:"userAgent"`
+	CollectInteractiveMetrics bool             `json:"collectInteractiveMetrics"`
+	Verifycertificates        bool             `json:"verifyCertificates"`
 }
 
 type Authentication struct {
@@ -83,6 +84,7 @@ type StepsV2 struct {
 	VariableName       string  `json:"variableName,omitempty"`
 	Value              string  `json:"value,omitempty"`
 	Options            Options `json:"options,omitempty"`
+	Duration           int     `json:"duration,omitempty"`
 }
 
 type Options struct {
@@ -120,14 +122,21 @@ type Setup struct {
 	Source    string `json:"source,omitempty"`
 	Type      string `json:"type,omitempty"`
 	Variable  string `json:"variable,omitempty"`
+	Code      string `json:"code,omitempty"`
+	Value     string `json:"value,omitempty"`
 }
 
 type Validations struct {
 	Actual     string `json:"actual,omitempty"`
 	Comparator string `json:"comparator,omitempty"`
 	Expected   string `json:"expected,omitempty"`
+	Extractor  string `json:"extractor,omitempty"`
 	Name       string `json:"name,omitempty"`
+	Source     string `json:"source,omitempty"`
 	Type       string `json:"type,omitempty"`
+	Variable   string `json:"variable,omitempty"`
+	Code       string `json:"code,omitempty"`
+	Value      string `json:"value,omitempty"`
 }
 
 type Tests []struct {
@@ -273,7 +282,7 @@ type HttpCheckV2Response struct {
 		RequestMethod      string          `json:"requestMethod"`
 		Body               string          `json:"body,omitempty"`
 		Authentication     *Authentication `json:"authentication"`
-		UserAgent          string          `json:"userAgent,omitempty"`
+		UserAgent          *string         `json:"userAgent"`
 		Verifycertificates bool            `json:"verifyCertificates"`
 		HttpHeaders        []HttpHeaders   `json:"headers,omitempty"`
 	} `json:"test"`
@@ -291,7 +300,7 @@ type HttpCheckV2Input struct {
 		RequestMethod      string          `json:"requestMethod"`
 		Body               string          `json:"body,omitempty"`
 		Authentication     *Authentication `json:"authentication"`
-		UserAgent          string          `json:"userAgent,omitempty"`
+		UserAgent          *string         `json:"userAgent"`
 		Verifycertificates bool            `json:"verifyCertificates"`
 		HttpHeaders        []HttpHeaders   `json:"headers,omitempty"`
 	} `json:"test"`

--- a/syntheticsclientv2/integration_test.go
+++ b/syntheticsclientv2/integration_test.go
@@ -40,7 +40,7 @@ var (
 	inputHttpCheckV2Data            = HttpCheckV2Input{}
 	updateHttpCheckV2Body           = `{"test":{"name":"a-maximal-http-integration-test-update","type":"http","url":"https://www.splunk.com/updated","locationIds":["aws-us-east-1","aws-ap-southeast-2","aws-ap-southeast-4"],"frequency":30,"schedulingStrategy":"round_robin","active":true,"requestMethod":"GET","body":null,"headers":[{"name":"header-1","value":"value-1"},{"name":"header_2","value":"value_2"}],"validations":[{"type":"assert_string","actual":"{{response.first_byte_time}}","expected":"100","comparator":"equals"},{"type":"assert_string","actual":"{{headers.Content-Length}}","expected":"100","comparator":"does_not_equal"}],"userAgent":"user-agent_standards met","authentication":{"username":"beepusers","password":"{{env.terraform-test-foo-301}}"},"verifyCertificates":true}}`
 	updateHttpCheckV2Data           = HttpCheckV2Input{}
-	createMaximalBrowserCheckV2Body = `{"test":{"name":"a-maximal-browser-beep-test","transactions":[{"name":"Synthetic transaction 1","steps":[{"name":"Go to URL","type":"go_to_url","url":"https://splunk.com","action":"go_to_url","options":{"url":"https://splunk.com"},"waitForNav":true},{"name":"click","type":"click_element","selectorType":"id","selector":"clicky","waitForNav":true},{"name":"fill in fieldz","type":"enter_value","selectorType":"id","selector":"beep","value":"{{env.beep-var}}","waitForNav":false},{"name":"accept---Alert","type":"accept_alert"},{"name":"Select-Val-Index","type":"select_option","selectorType":"id","selector":"selectionz","optionSelectorType":"index","optionSelector":"{{env.beep-var}}","waitForNav":false},{"name":"Select-val-text","type":"select_option","selectorType":"id","selector":"textzz","optionSelectorType":"text","optionSelector":"sdad","waitForNav":false},{"name":"Select-Val-Val","type":"select_option","selectorType":"id","selector":"valz","optionSelectorType":"value","optionSelector":"{{env.beep-var}}","waitForNav":false},{"name":"Run JS","type":"run_javascript","value":"beeeeeeep","waitForNav":true},{"name":"Save as text","type":"store_variable_from_element","selectorType":"link","selector":"beepval","variableName":"{{env.terraform-test-foo-301}}"},{"name":"Save JS return Val","type":"store_variable_from_javascript","value":"sdasds","variableName":"{{env.terraform-test-foo-301}}","waitForNav":true}]}],"urlProtocol":"https://","startUrl":"www.splunk.com","locationIds":["aws-us-east-1"],"deviceId":1,"frequency":5,"schedulingStrategy":"round_robin","active":true,"advancedSettings":{"verifyCertificates":true,"authentication":{"username":"boopuser","password":"{{env.beep-var}}"},"headers":[{"name":"batman","value":"Agentoz","domain":"www.batmansagent.com"}],"cookies":[{"key":"super","value":"duper","domain":"www.batmansagent.com","path":"/boom/goes/beep"}]}}}`
+	createMaximalBrowserCheckV2Body = `{"test":{"name":"a-maximal-browser-beep-test","transactions":[{"name":"Synthetic transaction 1","steps":[{"name":"Go to URL","type":"go_to_url","url":"https://splunk.com","action":"go_to_url","options":{"url":"https://splunk.com"},"waitForNav":true},{"name":"click","type":"click_element","selectorType":"id","selector":"clicky","waitForNav":true},{"name":"fill in fieldz","type":"enter_value","selectorType":"id","selector":"beep","value":"{{env.beep-var}}","waitForNav":false},{"name":"accept---Alert","type":"accept_alert"},{"name":"Select-Val-Index","type":"select_option","selectorType":"id","selector":"selectionz","optionSelectorType":"index","optionSelector":"{{env.beep-var}}","waitForNav":false},{"name":"Select-val-text","type":"select_option","selectorType":"id","selector":"textzz","optionSelectorType":"text","optionSelector":"sdad","waitForNav":false},{"name":"Select-Val-Val","type":"select_option","selectorType":"id","selector":"valz","optionSelectorType":"value","optionSelector":"{{env.beep-var}}","waitForNav":false},{"name":"Run JS","type":"run_javascript","value":"beeeeeeep","waitForNav":true},{"name":"Save as text","type":"store_variable_from_element","selectorType":"link","selector":"beepval","variableName":"{{env.terraform-test-foo-301}}"},{"name":"Wait","type":"wait","duration":1312},{"name":"Save JS return Val","type":"store_variable_from_javascript","value":"sdasds","variableName":"{{env.terraform-test-foo-301}}","waitForNav":true}]}],"urlProtocol":"https://","startUrl":"www.splunk.com","locationIds":["aws-us-east-1"],"deviceId":1,"frequency":5,"schedulingStrategy":"round_robin","active":true,"advancedSettings":{"verifyCertificates":true,"authentication":{"username":"boopuser","password":"{{env.beep-var}}"},"headers":[{"name":"batman","value":"Agentoz","domain":"www.batmansagent.com"}],"cookies":[{"key":"super","value":"duper","domain":"www.batmansagent.com","path":"/boom/goes/beep"}]}}}`
 	createMinimalBrowserCheckV2Body = `{"test":{"name":"a-minimal-browser-beep-test","transactions":[{"name":"Synthetic transaction 1","steps":[{"name":"Go to URL","type":"go_to_url","url":"https://splunk.com","action":"go_to_url"}]}],"locationIds":["aws-us-east-1"],"deviceId":1,"frequency":5,"schedulingStrategy":"round_robin","active":true,"advancedSettings":{"verifyCertificates":true}}}`
 	inputBrowserCheckV2Data         = BrowserCheckV2Input{}
 	updateBrowserCheckV2Body        = `{"test":{"name":"a-browser-beep-test","transactions":[{"name":"Synthetic transaction 1","steps":[{"name":"Go to URL","type":"go_to_url","url":"https://splunk.com","action":"go_to_url","options":{"url":"https://splunk.com"},"waitForNav":true},{"name":"click","type":"click_element","selectorType":"id","selector":"clicky","waitForNav":true},{"name":"fill in fieldz","type":"enter_value","selectorType":"id","selector":"beep","value":"{{env.beep-var}}","waitForNav":false},{"name":"accept---Alert","type":"accept_alert"},{"name":"Select-Val-Index","type":"select_option","selectorType":"id","selector":"selectionz","optionSelectorType":"index","optionSelector":"{{env.beep-var}}","waitForNav":false},{"name":"Select-val-text","type":"select_option","selectorType":"id","selector":"textzz","optionSelectorType":"text","optionSelector":"sdad","waitForNav":false},{"name":"Select-Val-Val","type":"select_option","selectorType":"id","selector":"valz","optionSelectorType":"value","optionSelector":"{{env.beep-var}}","waitForNav":false},{"name":"Run JS","type":"run_javascript","value":"beeeeeeep","waitForNav":true},{"name":"Save as text","type":"store_variable_from_element","selectorType":"link","selector":"beepval","variableName":"{{env.terraform-test-foo-301}}"},{"name":"Save JS return Val","type":"store_variable_from_javascript","value":"sdasds","variableName":"{{env.terraform-test-foo-301}}","waitForNav":true}]}],"urlProtocol":"https://","startUrl":"www.splunk.com","locationIds":["aws-us-east-1"],"deviceId":1,"frequency":15,"schedulingStrategy":"round_robin","active":true,"advancedSettings":{"verifyCertificates":true,"authentication":{"username":"boopuser","password":"{{env.beep-var}}"},"headers":[{"name":"batman","value":"Agentoz","domain":"www.batmansagent.com"}],"cookies":[{"key":"super","value":"dooper","domain":"www.batmansagent.com","path":"/boom/goes/beep"}]}}}`
@@ -49,7 +49,7 @@ var (
 	inputPortCheckV2Data            = PortCheckV2Input{}
 	updatePortCheckV2Body           = `{"test":{"name":"a2 - port 443 check","type":"port","url":"","port":448,"protocol":"tcp","host":"www.splunk.com","locationIds":["aws-us-east-1"],"frequency":10,"schedulingStrategy":"round_robin","active":true}}`
 	updatePortCheckV2Data           = PortCheckV2Input{}
-	createApiV2Body                 = `{"test":{"active":true,"deviceId":1,"frequency":5,"locationIds":["aws-us-east-1"],"name":"a-maximual-API-boop-test","schedulingStrategy":"round_robin","requests":[{"configuration":{"name":"Get-Test","requestMethod": "GET","url":"https://api.us1.signalfx.com/v2/synthetics/tests/api/489","headers":{"X-SF-TOKEN":"jinglebellsbatmanshells", "beep":"boop"},"body":null},"setup":[{"name":"Extract from response body","type":"extract_json","source":"{{response.body}}","extractor":"$.requests","variable":"custom-varz"}],"validations":[{"name":"Assert response code equals 200","type":"assert_numeric","actual":"{{response.code}}","expected":"200","comparator":"equals"}]}]}}`
+	createApiV2Body                 = `{"test":{"active":true,"deviceId":1,"frequency":5,"locationIds":["aws-us-east-1"],"name":"a-maximual-API-boop-test","schedulingStrategy":"round_robin","requests":[{"configuration":{"name":"Get-Test","requestMethod":"GET","url":"https://api.us1.signalfx.com/v2/synthetics/tests/api/489","headers":{"X-SF-TOKEN":"jinglebellsbatmanshells","beep":"boop"},"body":null},"setup":[{"name":"Extract from response body","type":"extract_json","source":"{{response.body}}","extractor":"sd","variable":"extractsetupvar"},{"name":"JavaScript run","type":"javascript","code":"asdasd","variable":"jsvarsetup"},{"name":"Save response body","type":"save","value":"{{response.body}}","variable":"savesetupvar"}],"validations":[{"name":"JavaScript run","type":"javascript","code":"codetorun","variable":"jscodevar"},{"name":"Save response body","type":"save","value":"{{response.body}}","variable":"saverespvar"},{"name":"Assert response code equals 200","type":"assert_numeric","actual":"{{response.code}}","expected":"200","comparator":"equals"},{"name":"Extract from response body","type":"extract_json","source":"{{response.body}}","extractor":"js.extractor","variable":"extractjvar"}]}]}}`
 	createMinimalApiV2Body          = `{"test":{"active":true,"deviceId":1,"frequency":5,"locationIds":["aws-us-east-1"],"name":"a-minimal-API-boop-test","schedulingStrategy":"round_robin","requests":[{"configuration":{"name":"apishortGet-Test","requestMethod":"GET","url":"https://api.us1.signalfx.com/v2/synthetics/tests/api/489"}}]}}`
 	inputApiCheckV2Data             = ApiCheckV2Input{}
 	updateApiCheckV2Body            = `{"test":{"active":true,"deviceId":1,"frequency":5,"locationIds":["aws-us-east-1"],"name":"a-API-boop-test","schedulingStrategy":"round_robin","requests":[{"configuration":{"name":"Get-Test","requestMethod": "GET","url":"https://api.us1.signalfx.com/v2/synthetics/tests/api/4892","headers":{"X-SF-TOKEN":"jinglebellsbatmanshells", "beep":"boop"},"body":null},"setup":[{"name":"Extract from response body","type":"extract_json","source":"{{response.body}}","extractor":"$.requests","variable":"custom-varz"}],"validations":[{"name":"Assert response code equals 200","type":"assert_numeric","actual":"{{response.code}}","expected":"200","comparator":"equals"}]}]}}`
@@ -411,7 +411,7 @@ func UpdateBrowserCheckV2(checkId int, test string, c *Client) error {
 	}
 	fmt.Println(reqDetail)
 	JsonPrint(res)
-	
+
 	return nil
 }
 
@@ -420,7 +420,7 @@ func GetBrowserCheckV2(checkId int, c *Client) error {
 	res, _, err := c.GetBrowserCheckV2(checkId)
 	if err != nil {
 		return err
-	} 
+	}
 	JsonPrint(res)
 
 	return nil
@@ -433,7 +433,7 @@ func DeleteBrowserCheckV2(checkId int, c *Client) error {
 		return err
 	}
 	JsonPrint(res)
-	
+
 	return nil
 }
 
@@ -517,7 +517,7 @@ func UpdateApiCheckV2(checkId int, test string, c *Client) error {
 	}
 	fmt.Println(reqDetail)
 	JsonPrint(res)
-	
+
 	return nil
 }
 
@@ -526,7 +526,7 @@ func GetApiCheckV2(checkId int, c *Client) error {
 	res, _, err := c.GetApiCheckV2(checkId)
 	if err != nil {
 		return err
-	} 
+	}
 	JsonPrint(res)
 
 	return nil
@@ -539,7 +539,7 @@ func DeleteApiCheckV2(checkId int, c *Client) error {
 		return err
 	}
 	JsonPrint(res)
-	
+
 	return nil
 }
 
@@ -661,7 +661,7 @@ func UpdatePortCheckV2(checkId int, test string, c *Client) error {
 	}
 	fmt.Println(reqDetail)
 	JsonPrint(res)
-	
+
 	return nil
 }
 
@@ -670,7 +670,7 @@ func GetPortCheckV2(checkId int, c *Client) error {
 	res, _, err := c.GetPortCheckV2(checkId)
 	if err != nil {
 		return err
-	} 
+	}
 	JsonPrint(res)
 
 	return nil
@@ -683,7 +683,7 @@ func DeletePortCheckV2(checkId int, c *Client) error {
 		return err
 	}
 	JsonPrint(res)
-	
+
 	return nil
 }
 


### PR DESCRIPTION
## Continued updates for EP3 to match latest API changes
**Breaking:** `UserAgent` needs to be a pointer so we can properly send a `null` when not part of a `devices` block

**Other Changes:**
- validations fields updated
- setup fields updated
- add duration field for steps
- collect interactive metrics field added
- integration tests updated for new fields
- linting