### PR TITLE
Add Validations field to HTTP Check

### DIFF
--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -304,7 +304,7 @@ type HttpCheckV2Input struct {
 		UserAgent          *string         `json:"userAgent"`
 		Verifycertificates bool            `json:"verifyCertificates"`
 		HttpHeaders        []HttpHeaders   `json:"headers,omitempty"`
-		Validation         []Validations   `json:"validations,omitempty"`
+		Validations         []Validations   `json:"validations,omitempty"`
 	} `json:"test"`
 }
 

--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -285,7 +285,7 @@ type HttpCheckV2Response struct {
 		UserAgent          *string         `json:"userAgent"`
 		Verifycertificates bool            `json:"verifyCertificates"`
 		HttpHeaders        []HttpHeaders   `json:"headers,omitempty"`
-		Validations        []Validations   `json:"validations,omitempty"`
+		Validations        []Validations   `json:"validations"`
 	} `json:"test"`
 }
 
@@ -304,7 +304,7 @@ type HttpCheckV2Input struct {
 		UserAgent          *string         `json:"userAgent"`
 		Verifycertificates bool            `json:"verifyCertificates"`
 		HttpHeaders        []HttpHeaders   `json:"headers,omitempty"`
-		Validations        []Validations   `json:"validations,omitempty"`
+		Validations        []Validations   `json:"validations"`
 	} `json:"test"`
 }
 

--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -304,7 +304,7 @@ type HttpCheckV2Input struct {
 		UserAgent          *string         `json:"userAgent"`
 		Verifycertificates bool            `json:"verifyCertificates"`
 		HttpHeaders        []HttpHeaders   `json:"headers,omitempty"`
-		Validations         []Validations   `json:"validations,omitempty"`
+		Validations        []Validations   `json:"validations,omitempty"`
 	} `json:"test"`
 }
 

--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -285,6 +285,7 @@ type HttpCheckV2Response struct {
 		UserAgent          *string         `json:"userAgent"`
 		Verifycertificates bool            `json:"verifyCertificates"`
 		HttpHeaders        []HttpHeaders   `json:"headers,omitempty"`
+		Validations		   []Validations   `json:"validations,omitempty"`
 	} `json:"test"`
 }
 
@@ -303,6 +304,7 @@ type HttpCheckV2Input struct {
 		UserAgent          *string         `json:"userAgent"`
 		Verifycertificates bool            `json:"verifyCertificates"`
 		HttpHeaders        []HttpHeaders   `json:"headers,omitempty"`
+		Validations		   []Validations   `json:"validations,omitempty"`
 	} `json:"test"`
 }
 

--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -285,7 +285,7 @@ type HttpCheckV2Response struct {
 		UserAgent          *string         `json:"userAgent"`
 		Verifycertificates bool            `json:"verifyCertificates"`
 		HttpHeaders        []HttpHeaders   `json:"headers,omitempty"`
-		Validations		   []Validations   `json:"validations,omitempty"`
+		Validations        []Validations   `json:"validations,omitempty"`
 	} `json:"test"`
 }
 
@@ -304,7 +304,7 @@ type HttpCheckV2Input struct {
 		UserAgent          *string         `json:"userAgent"`
 		Verifycertificates bool            `json:"verifyCertificates"`
 		HttpHeaders        []HttpHeaders   `json:"headers,omitempty"`
-		Validations		   []Validations   `json:"validations,omitempty"`
+		Validation         []Validations   `json:"validations,omitempty"`
 	} `json:"test"`
 }
 

--- a/syntheticsclientv2/create_httpcheckv2.go
+++ b/syntheticsclientv2/create_httpcheckv2.go
@@ -33,6 +33,11 @@ func parseCreateHttpCheckV2Response(response string) (*HttpCheckV2Response, erro
 
 func (c Client) CreateHttpCheckV2(HttpCheckV2Details *HttpCheckV2Input) (*HttpCheckV2Response, *RequestDetails, error) {
 
+	if HttpCheckV2Details.Test.Validations == nil {
+		validation := make([]Validations, 0)
+		HttpCheckV2Details.Test.Validations = validation
+	}
+
 	body, err := json.Marshal(HttpCheckV2Details)
 	if err != nil {
 		return nil, nil, err

--- a/syntheticsclientv2/integration_test.go
+++ b/syntheticsclientv2/integration_test.go
@@ -245,12 +245,13 @@ func CreateHttpCheckV2(test string, c *Client) (int, error) {
 	}
 	fmt.Printf("\nReq was: \n%v\n", reqDetail)
 	JsonPrint(res)
+	inputHttpCheckV2Data = HttpCheckV2Input{}
 
 	return res.Test.ID, nil
 }
 
 func UpdateHttpCheckV2(checkId int, test string, c *Client) error {
-
+	
 	err := json.Unmarshal([]byte(test), &inputHttpCheckV2Data)
 	if err != nil {
 		return err
@@ -263,6 +264,7 @@ func UpdateHttpCheckV2(checkId int, test string, c *Client) error {
 	}
 	fmt.Printf("\nReq was: \n%v\n", reqDetail)
 	JsonPrint(res)
+	inputHttpCheckV2Data = HttpCheckV2Input{}
 
 	return nil
 }

--- a/syntheticsclientv2/update_httpcheckv2.go
+++ b/syntheticsclientv2/update_httpcheckv2.go
@@ -33,6 +33,10 @@ func parseUpdateHttpCheckV2Response(response string) (*HttpCheckV2Response, erro
 }
 
 func (c Client) UpdateHttpCheckV2(id int, HttpCheckV2Details *HttpCheckV2Input) (*HttpCheckV2Response, *RequestDetails, error) {
+	if HttpCheckV2Details.Test.Validations == nil {
+		validation := make([]Validations, 0)
+		HttpCheckV2Details.Test.Validations = validation
+	}
 
 	body, err := json.Marshal(HttpCheckV2Details)
 	if err != nil {


### PR DESCRIPTION
This PR aims to add Validations to the HTTP check which is available through the API.

The integration test already has validations as part of the update so I didn't change anything there.