### PR TITLE
add boilerplate CLA, COC, and Contribution docs. CLA workflow to come

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,52 @@
+Contributions to Splunk
+In order to contribute to a Splunk open source project, please:
+
+Read the agreement below
+Fill out the form
+Indicate your acceptance of the terms
+Then proceed to the GitHub and issue an pull request (if you haven't already) for the project or projects that you would like to contribute to and we will take it from there.
+
+ 
+
+Splunk Contributor License Agreement ("Agreement")
+You accept and agree to the following terms and conditions for Your present and future Contributions submitted to Splunk Inc. ("Splunk"). Except for the license granted herein to Splunk and recipients of software distributed by Splunk, You reserve all right, title, and interest in and to Your Contributions.
+
+ 
+
+1. Definitions.
+
+ 
+
+"You" (or "Your") shall mean the copyright owner or legal entity authorized by the copyright owner that is making this Agreement with Splunk. For legal entities, the entity making a Contribution and all other entities that control, are controlled by, or are under common control with that entity are considered to be a single Contributor. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+ 
+
+"Contribution" shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to Splunk for inclusion in, or documentation of, any of the products owned or managed by Splunk (the "Work"). For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to Splunk or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, Splunk for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
+
+ 
+
+2. Grant of Copyright License. Subject to the terms and conditions of this Agreement, You hereby grant to Splunk and to recipients of software distributed by Splunk a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
+
+ 
+
+3. Grant of Patent License. Subject to the terms and conditions of this Agreement, You hereby grant to Splunk and to recipients of software distributed by Splunk a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Work to which such Contribution(s) was submitted. If any entity institutes patent litigation against You or any other entity (including a cross-claim or counterclaim in a lawsuit) alleging that your Contribution, or the Work to which you have contributed, constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this Agreement for that Contribution or Work shall terminate as of the date such litigation is filed.
+
+ 
+
+4. You represent that you are legally entitled to grant the above license. If your employer(s) has rights to intellectual property that you create that includes your Contributions, you represent that you have received permission to make Contributions on behalf of that employer, that your employer has waived such rights for your Contributions to Splunk, or that your employer has executed a separate Corporate CLA with Splunk.
+
+ 
+
+5. You represent that each of Your Contributions is Your original creation (see section 7 for submissions on behalf of others). You represent that Your Contribution submissions include complete details of any third-party license or other restriction (including, but not limited to, related patents and trademarks) of which you are personally aware and which are associated with any part of Your Contributions.
+
+ 
+
+6. You are not expected to provide support for Your Contributions, except to the extent You desire to provide support. You may provide support for free, for a fee, or not at all. Unless required by applicable law or agreed to in writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON- INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+ 
+
+7. Should You wish to submit work that is not Your original creation, You may submit it to Splunk separately from any Contribution, identifying the complete details of its source and of any license or other restriction (including, but not limited to, related patents, trademarks, and license agreements) of which you are personally aware, and conspicuously marking the work as "Submitted on behalf of a third-party: [named here]".
+
+ 
+
+8. You agree to notify Splunk of any facts or circumstances of which you become aware that would make these representations inaccurate in any respect.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at splunk-oss-admin@splunk.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+Contributions are encouraged and greatly appreciated! Every
+little bit helps, and credit will always be given.
+
+You can contribute in many ways:
+
+## Types of Contributions
+
+### Report Bugs/Issues:
+
+If you are reporting a bug or issues, please include:
+
+-   Operating system name and version.
+-   Any details about your local setup that might be helpful
+    in troubleshooting (E.G. Python version if using a python script, Terraform version if you're using a Terraform script.).
+-   Detailed steps to reproduce the bug.
+
+### Fix Bugs
+
+Check the Issues for this repo on GitHub. Anything tagged with
+a "bug" ticket type is open to whoever wants to implement it.
+
+### Implement Features
+
+If you have a great set of dashboards, detectors, API scripts for sending metrics, or any other content 
+you believe will be of use to others, please contribute it!
+
+Or check the Issues for this repo on GitHub. Anything tagged with "enhancement"
+and "help wanted" is open to whoever wants to implement it.
+
+### Write Documentation
+
+Submissions and `README.md` files could always use more documentation. Documentation can always use an update or tweak in the official docs, in docstrings of scripts, comments in configs, or anywhere a bit of clarity may be useful..
+
+### Submit Feedback
+
+If you are proposing a feature:
+
+-   Explain in detail how it would work.
+-   Keep the scope as narrow as possible, to make it easier
+    to implement.
+-   Remember that this is a volunteer-driven project, and that
+    contributions are welcome :)
+
+## Pull Request Guidelines
+
+Before you submit a pull request, check that it meets these guidelines:
+
+1.  The pull request should include a `README.md` for any new submission.
+2.  If the pull request adds functionality, the `README.md` docs for that component or submission should be updated.
+    Put your new functionality into a function with a docstring, and add
+    the feature to the list in README.md.
+3.  Terraform submissions should work with the most current version of the included Terraform Provider.
+4.  Python submissions should work for Python3


### PR DESCRIPTION
Adding boilerplate CLA, COC, Contribution doc.

Will add CLA agreement workflow but need these here first. In the mean time, manual agreement in Pull Requests will be required.