### PR TITLE
SYN-4026: Add optional port field to http tests

### DIFF
--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -303,6 +303,7 @@ type HttpCheckV2Response struct {
 		Customproperties   []CustomProperties `json:"customProperties"`
 		Lastrunstatus      string             `json:"lastRunStatus"`
 		Lastrunat          time.Time          `json:"lastRunAt"`
+    Port               int                `json:"port"`
 	} `json:"test"`
 }
 
@@ -323,6 +324,7 @@ type HttpCheckV2Input struct {
 		HttpHeaders        []HttpHeaders      `json:"headers,omitempty"`
 		Validations        []Validations      `json:"validations"`
 		Customproperties   []CustomProperties `json:"customProperties"`
+    Port               int                `json:"port"`
 	} `json:"test"`
 }
 

--- a/syntheticsclientv2/create_httpcheckv2_test.go
+++ b/syntheticsclientv2/create_httpcheckv2_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	createHttpCheckV2Body = `{"test":{"customProperties": [{"key": "Test_Key", "value": "Test Custom Properties"}], "name":"morebeeps-test","type":"http","url":"https://www.splunk.com","location_ids":["aws-us-east-1"],"frequency":10,"scheduling_strategy":"round_robin","active":true,"request_method":"GET","body":null,"headers":[{"name":"boop","value":"beep"}]}}`
+  createHttpCheckV2Body = `{"test":{"customProperties": [{"key": "Test_Key", "value": "Test Custom Properties"}], "port": 443, "name":"morebeeps-test","type":"http","url":"https://www.splunk.com","location_ids":["aws-us-east-1"],"frequency":10,"scheduling_strategy":"round_robin","active":true,"request_method":"GET","body":null,"headers":[{"name":"boop","value":"beep"}]}}`
 	inputHttpCheckV2Data  = HttpCheckV2Input{}
 )
 
@@ -85,5 +85,9 @@ func TestCreateHttpCheckV2(t *testing.T) {
 
 	if !reflect.DeepEqual(resp.Test.Customproperties, inputHttpCheckV2Data.Test.Customproperties) {
 		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Customproperties, inputHttpCheckV2Data.Test.Customproperties)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Port, inputHttpCheckV2Data.Test.Port) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Port, inputHttpCheckV2Data.Test.Port)
 	}
 }

--- a/syntheticsclientv2/get_httpcheckv2_test.go
+++ b/syntheticsclientv2/get_httpcheckv2_test.go
@@ -101,6 +101,10 @@ func TestGetHttpCheckV2(t *testing.T) {
 	if !reflect.DeepEqual(resp.Test.Customproperties, inputGetHttpCheckV2.Test.Customproperties) {
 		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Customproperties, inputGetHttpCheckV2.Test.Customproperties)
 	}
+
+	if !reflect.DeepEqual(resp.Test.Port, inputGetHttpCheckV2.Test.Port) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Port, inputGetHttpCheckV2.Test.Port)
+	}
 }
 
 func verifyHttpCheckV2Input(stringInput string) *HttpCheckV2Response {

--- a/syntheticsclientv2/get_httpcheckv2_test.go
+++ b/syntheticsclientv2/get_httpcheckv2_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	getHttpCheckV2Body  = `{"test":{"customProperties": [{"key": "Test_Key", "value": "Test Custom Properties"}], "active":true,"advancedSettings":{"authentication":{"password":"password123","username":"myuser"},"cookies":[{"key":"qux","value":"qux","domain":"splunk.com","path":"/qux"}],"headers":[{"name":"Accept","value":"application/json","domain":"splunk.com"}],"verifyCertificates":true},"createdAt":"2022-09-14T14:35:37.801Z","device":{"id":1,"label":"iPhone","networkConnection":{"description":"Mobile LTE","downloadBandwidth":12000,"latency":70,"packetLoss":0,"uploadBandwidth":12000},"viewportHeight":844,"viewportWidth":375},"frequency":5,"id":1,"locationIds":["na-us-virginia"],"name":"My Test","schedulingStrategy":"round_robin","transactions":[{"name":"Example transaction","steps":[{"name":"element step","selector":".main","selectorType":"css","type":"click_element","waitForNav":true}]}],"type":"browser","updatedAt":"2022-09-14T14:35:38.099Z","lastRunAt":"2024-03-07T00:47:43.741Z","lastRunStatus":"success"}}`
+  getHttpCheckV2Body  = `{"test":{"customProperties": [{"key": "Test_Key", "value": "Test Custom Properties"}], "active":true,"createdAt":"2022-09-14T14:35:37.801Z","frequency":5,"id":1,"locationIds":["na-us-virginia"],"name":"My Test","schedulingStrategy":"round_robin","type":"http","updatedAt":"2022-09-14T14:35:38.099Z","lastRunAt":"2024-03-07T00:47:43.741Z","lastRunStatus":"success","url":"https://splunk.com","requestMethod":"GET","body":null,"headers":[{"name":"Accept","value":"application/json","domain":"splunk.com"}],"userAgent":null,"validations":[],"verifyCertificates":false,"authentication":null,"port":null}}`
 	inputGetHttpCheckV2 = verifyHttpCheckV2Input(string(getHttpCheckV2Body))
 )
 

--- a/syntheticsclientv2/update_httpcheckv2_test.go
+++ b/syntheticsclientv2/update_httpcheckv2_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	updateHttpCheckV2Body  = `{"test":{"customProperties": [{"key": "Test_Key", "value": "Test Custom Properties"}], "name":"morebeeps-test","type":"http","url":"https://www.splunk.com","location_ids":["aws-us-east-1"],"frequency":10,"scheduling_strategy":"round_robin","active":true,"request_method":"GET","body":null,"headers":[{"name":"boop","value":"beep"}]}}`
+  updateHttpCheckV2Body  = `{"test":{"customProperties": [{"key": "Test_Key", "value": "Test Custom Properties"}], "name":"morebeeps-test","type":"http","url":"https://www.splunk.com","location_ids":["aws-us-east-1"],"frequency":10,"scheduling_strategy":"round_robin","active":true,"request_method":"GET","body":null,"port":443,"headers":[{"name":"boop","value":"beep"}]}}`
 	inputHttpCheckV2Update = HttpCheckV2Input{}
 )
 
@@ -60,5 +60,9 @@ func TestUpdateHttpCheckV2(t *testing.T) {
 
 	if !reflect.DeepEqual(resp.Test.Customproperties, inputHttpCheckV2Update.Test.Customproperties) {
 		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Customproperties, inputHttpCheckV2Update.Test.Customproperties)
+	}
+
+	if !reflect.DeepEqual(resp.Test.Port, inputHttpCheckV2Update.Test.Port) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Port, inputHttpCheckV2Update.Test.Port)
 	}
 }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves [SYN-4026](https://splunk.atlassian.net/browse/SYN-4026)

----

### Before the change?
The request and response body for http tests did not support a port field.

* 

### After the change?
Adds optional port field to request and response for http tests. I also noticed that `createHttpCheckV2Body` was actually a body for a browser test, so I changed it to reflect an http test.

* 

### Pull request checklist 
- [ ] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
<!-- Please paste the results of acceptance tests `make testacc` in the codeblock here. -->
```

```

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----
