### PR TITLE
SYN-4606: Add WaitForNavTimeoutDefault and MaxWaitTimeDefault

### DIFF
--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -82,21 +82,23 @@ type BusinessTransactions struct {
 }
 
 type StepsV2 struct {
-	Name               string  `json:"name"`
-	Type               string  `json:"type"`
-	URL                string  `json:"url,omitempty"`
-	Action             string  `json:"action,omitempty"`
-	WaitForNav         bool    `json:"waitForNav"`
-	WaitForNavTimeout  int     `json:"waitForNavTimeout,omitempty"`
-	MaxWaitTime        int     `json:"maxWaitTime,omitempty"`
-	SelectorType       string  `json:"selectorType,omitempty"`
-	Selector           string  `json:"selector,omitempty"`
-	OptionSelectorType string  `json:"optionSelectorType,omitempty"`
-	OptionSelector     string  `json:"optionSelector,omitempty"`
-	VariableName       string  `json:"variableName,omitempty"`
-	Value              string  `json:"value,omitempty"`
-	Options            Options `json:"options,omitempty"`
-	Duration           int     `json:"duration,omitempty"`
+	Name                     string  `json:"name"`
+	Type                     string  `json:"type"`
+	URL                      string  `json:"url,omitempty"`
+	Action                   string  `json:"action,omitempty"`
+	WaitForNav               bool    `json:"waitForNav"`
+	WaitForNavTimeout        int     `json:"waitForNavTimeout,omitempty"`
+	WaitForNavTimeoutDefault bool    `json:"waitForNavTimeoutDefault,omitempty"`
+	MaxWaitTime              int     `json:"maxWaitTime,omitempty"`
+	MaxWaitTimeDefault       bool    `json:"maxWaitTimeDefault,omitempty"`
+	SelectorType             string  `json:"selectorType,omitempty"`
+	Selector                 string  `json:"selector,omitempty"`
+	OptionSelectorType       string  `json:"optionSelectorType,omitempty"`
+	OptionSelector           string  `json:"optionSelector,omitempty"`
+	VariableName             string  `json:"variableName,omitempty"`
+	Value                    string  `json:"value,omitempty"`
+	Options                  Options `json:"options,omitempty"`
+	Duration                 int     `json:"duration,omitempty"`
 }
 
 type Options struct {
@@ -444,26 +446,28 @@ type BrowserCheckV2Input struct {
 }
 
 type BrowserCheckV2Response struct {
-	Test struct {
-		Active             bool `json:"active"`
-		Advancedsettings   `json:"advancedSettings"`
-		Createdat          time.Time `json:"createdAt"`
-		Device             `json:"device"`
-		Frequency          int                `json:"frequency"`
-		ID                 int                `json:"id"`
-		Locationids        []string           `json:"locationIds"`
-		Name               string             `json:"name"`
-		Schedulingstrategy string             `json:"schedulingStrategy"`
-		Transactions       []Transactions     `json:"transactions"`
-		Type               string             `json:"type"`
-		Updatedat          time.Time          `json:"updatedAt"`
-		Customproperties   []CustomProperties `json:"customProperties"`
-		Lastrunstatus      string             `json:"lastRunStatus"`
-		Lastrunat          time.Time          `json:"lastRunAt"`
-		Automaticretries   int                `json:"automaticRetries"`
-		Createdby          string             `json:"createdBy"`
-		Updatedby          string             `json:"updatedBy"`
-	} `json:"test"`
+	Test BrowserCheckV2ResponseTest `json:"test"`
+}
+
+type BrowserCheckV2ResponseTest struct {
+	Active             bool `json:"active"`
+	Advancedsettings   `json:"advancedSettings"`
+	Createdat          time.Time `json:"createdAt"`
+	Device             `json:"device"`
+	Frequency          int                `json:"frequency"`
+	ID                 int                `json:"id"`
+	Locationids        []string           `json:"locationIds"`
+	Name               string             `json:"name"`
+	Schedulingstrategy string             `json:"schedulingStrategy"`
+	Transactions       []Transactions     `json:"transactions"`
+	Type               string             `json:"type"`
+	Updatedat          time.Time          `json:"updatedAt"`
+	Customproperties   []CustomProperties `json:"customProperties"`
+	Lastrunstatus      string             `json:"lastRunStatus"`
+	Lastrunat          time.Time          `json:"lastRunAt"`
+	Automaticretries   int                `json:"automaticRetries"`
+	Createdby          string             `json:"createdBy"`
+	Updatedby          string             `json:"updatedBy"`
 }
 
 type CustomProperties struct {

--- a/syntheticsclientv2/get_browsercheckv2_test.go
+++ b/syntheticsclientv2/get_browsercheckv2_test.go
@@ -22,11 +22,77 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 )
 
 var (
-	getBrowserCheckV2Body  = `{"test":{"automaticRetries": 1, "customProperties": [{"key": "Test_Key", "value": "Test Custom Properties"}], "active":true,"advancedSettings":{"authentication":{"password":"password123","username":"myuser"},"cookies":[{"key":"qux","value":"qux","domain":"splunk.com","path":"/qux"}],"headers":[{"name":"Accept","value":"application/json","domain":"splunk.com"}],"verifyCertificates":true},"createdAt":"2022-09-14T14:35:37.801Z","device":{"id":1,"label":"iPhone","networkConnection":{"description":"Mobile LTE","downloadBandwidth":12000,"latency":70,"packetLoss":0,"uploadBandwidth":12000},"viewportHeight":844,"viewportWidth":375},"frequency":5,"id":1,"locationIds":["na-us-virginia"],"name":"My Test","schedulingStrategy":"round_robin","transactions":[{"name":"Example transaction","steps":[{"name":"element step","selector":".main","selectorType":"css","type":"click_element","waitForNav":true,"waitForNavTimeout":2000}]}],"type":"browser","updatedAt":"2022-09-14T14:35:38.099Z","lastRunAt":"2024-03-07T00:47:43.741Z","lastRunStatus":"success","createdBy":"abc1234","updatedBy":"abc1234"}}`
+	getBrowserCheckV2Body  = `{"test":{"automaticRetries": 1, "customProperties": [{"key": "Test_Key", "value": "Test Custom Properties"}], "active":true,"advancedSettings":{"authentication":{"password":"password123","username":"myuser"},"cookies":[{"key":"qux","value":"qux","domain":"splunk.com","path":"/qux"}],"headers":[{"name":"Accept","value":"application/json","domain":"splunk.com"}],"verifyCertificates":true},"createdAt":"2022-09-14T14:35:37.801Z","device":{"id":1,"label":"iPhone","networkConnection":{"description":"Mobile LTE","downloadBandwidth":12000,"latency":70,"packetLoss":0,"uploadBandwidth":12000},"viewportHeight":844,"viewportWidth":375},"frequency":5,"id":1,"locationIds":["na-us-virginia"],"name":"My Test","schedulingStrategy":"round_robin","transactions":[{"name":"Example transaction","steps":[{"name":"element step","selector":".main","selectorType":"css","type":"click_element","waitForNav":true,"waitForNavTimeout":2000,"waitForNavTimeoutDefault":true,"maxWaitTime":10000,"maxWaitTimeDefault":true}]}],"type":"browser","updatedAt":"2022-09-14T14:35:38.099Z","lastRunAt":"2024-03-07T00:47:43.741Z","lastRunStatus":"success","createdBy":"abc1234","updatedBy":"abc1234"}}`
 	inputGetBrowserCheckV2 = verifyBrowserCheckV2Input(string(getBrowserCheckV2Body))
+	expectedBrowserCheckV2 = BrowserCheckV2Response{
+		Test: BrowserCheckV2ResponseTest{
+			Automaticretries: 1,
+			Customproperties: []CustomProperties{
+				{Key: "Test_Key", Value: "Test Custom Properties"},
+			},
+			Active: true,
+			Advancedsettings: Advancedsettings{
+				Authentication: &Authentication{
+					Password: "password123",
+					Username: "myuser",
+				},
+				Cookiesv2: []Cookiesv2{
+					{Key: "qux", Value: "qux", Domain: "splunk.com", Path: "/qux"},
+				},
+				BrowserHeaders: []BrowserHeaders{
+					{Name: "Accept", Value: "application/json", Domain: "splunk.com"},
+				},
+				Verifycertificates: true,
+			},
+			Createdat: time.Date(2022, 9, 14, 14, 35, 37, 801000000, time.UTC),
+			Device: Device{
+				ID:    1,
+				Label: "iPhone",
+				Networkconnection: Networkconnection{
+					Description:       "Mobile LTE",
+					Downloadbandwidth: 12000,
+					Latency:           70,
+					Packetloss:        0,
+					Uploadbandwidth:   12000,
+				},
+				Viewportheight: 844,
+				Viewportwidth:  375,
+			},
+			Frequency:          5,
+			ID:                 1,
+			Locationids:        []string{"na-us-virginia"},
+			Name:               "My Test",
+			Schedulingstrategy: "round_robin",
+			Transactions: []Transactions{
+				{
+					Name: "Example transaction",
+					StepsV2: []StepsV2{
+						{
+							Name:                     "element step",
+							Selector:                 ".main",
+							SelectorType:             "css",
+							Type:                     "click_element",
+							WaitForNav:               true,
+							WaitForNavTimeout:        2000,
+							WaitForNavTimeoutDefault: true,
+							MaxWaitTime:              10000,
+							MaxWaitTimeDefault:       true,
+						},
+					},
+				},
+			},
+			Type:          "browser",
+			Updatedat:     time.Date(2022, 9, 14, 14, 35, 38, 99000000, time.UTC),
+			Lastrunat:     time.Date(2024, 3, 7, 0, 47, 43, 741000000, time.UTC),
+			Lastrunstatus: "success",
+			Createdby:     "abc1234",
+			Updatedby:     "abc1234",
+		},
+	}
 )
 
 func TestGetBrowserCheckV2(t *testing.T) {
@@ -46,6 +112,11 @@ func TestGetBrowserCheckV2(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// verify the json is unmarshalled correctly
+	if !reflect.DeepEqual(*inputGetBrowserCheckV2, expectedBrowserCheckV2) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", *inputGetBrowserCheckV2, expectedBrowserCheckV2)
+	}
+
 	if !reflect.DeepEqual(resp.Test.ID, inputGetBrowserCheckV2.Test.ID) {
 		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.ID, inputGetBrowserCheckV2.Test.ID)
 	}
@@ -89,6 +160,11 @@ func TestGetBrowserCheckV2(t *testing.T) {
 	if !reflect.DeepEqual(resp.Test.Customproperties, inputGetBrowserCheckV2.Test.Customproperties) {
 		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Customproperties, inputGetBrowserCheckV2.Test.Customproperties)
 	}
+
+	// verify the whole response
+	if !reflect.DeepEqual(*resp, expectedBrowserCheckV2) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", *resp, expectedBrowserCheckV2)
+	}
 }
 
 func verifyBrowserCheckV2Input(stringInput string) *BrowserCheckV2Response {
@@ -96,6 +172,10 @@ func verifyBrowserCheckV2Input(stringInput string) *BrowserCheckV2Response {
 	err := json.Unmarshal([]byte(stringInput), check)
 	if err != nil {
 		panic(err)
+	}
+	empty := BrowserCheckV2Response{}
+	if reflect.DeepEqual(empty, *check) {
+		panic("Unmarshal failed, empty struct returned")
 	}
 	return check
 }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves SYN-4606

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* No way how to find out if the WaitForNavTimeout and MaxWaitTime browser check step fields were set to some value or the default value is being used. This information is needed in the Synthetics Terraform provider to properly handle default values.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Added WaitForNavTimeoutDefault and MaxWaitTimeDefault boolean flags. When true, the value in the respective attributes is the default one provided by the API. If false, the value was set to the value by the user in UI or through the Synthetics API.

### Pull request checklist 
- [x] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
<!-- Please paste the results of acceptance tests `make testacc` in the codeblock here. -->
```
PASS
coverage: 70.3% of statements
ok      github.com/splunk/syntheticsclient/v2/syntheticsclientv2        1.343s  coverage: 70.3% of statements
```

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----
