### PR TITLE
SYN-5006: Expose status code for api errors

### DIFF
--- a/syntheticsclientv2/synthetics.go
+++ b/syntheticsclientv2/synthetics.go
@@ -96,6 +96,9 @@ func (c Client) makePublicAPICall(method string, endpoint string, requestBody io
 		return &details, err
 	}
 
+	details.StatusCode = resp.StatusCode
+	details.RawResponse = resp
+
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
 		var errRes errorResponse
 		if err = json.NewDecoder(resp.Body).Decode(&errRes); err == nil {
@@ -113,9 +116,7 @@ func (c Client) makePublicAPICall(method string, endpoint string, requestBody io
 		return &details, err
 	}
 
-	details.StatusCode = resp.StatusCode
 	details.ResponseBody = string(responseBody)
-	details.RawResponse = resp
 
 	return &details, nil
 }

--- a/syntheticsclientv2/synthetics_test.go
+++ b/syntheticsclientv2/synthetics_test.go
@@ -98,3 +98,26 @@ func TestConfigurableClientTimeout(t *testing.T) {
 		t.Errorf("expected to see timeout error, but saw: %s", err.Error())
 	}
 }
+
+func TestConfigurableClientErrorStatusCode(t *testing.T) {
+	testMux = http.NewServeMux()
+	testServer = httptest.NewServer(testMux)
+
+	testMux.HandleFunc("/tests", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"status":"404"}`))
+	})
+
+	testConfigurableClient := NewConfigurableClient("apiKey", "realm", ClientArgs{
+		publicBaseUrl: testServer.URL,
+	})
+	details, err := testConfigurableClient.makePublicAPICall("GET", "/tests", nil, nil)
+
+	if !strings.Contains(err.Error(), "404 Not Found") {
+		t.Errorf("expected to see 404 error, but saw: %s", err.Error())
+	}
+
+	if details.StatusCode != http.StatusNotFound {
+		t.Errorf("expected to see 404 status code, but saw: %d", details.StatusCode)
+	}
+}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The result returned by makePublicAPICall doesn't contain the response status code when the api requests fails (<200,>=400).

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The makePublicAPICall contains the correct `StatusCode` and `RawResponse` so it can be further processed by the application that is using this client.

### Pull request checklist 
- [x] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
<!-- Please paste the results of acceptance tests `make testacc` in the codeblock here. -->
```
PASS
coverage: 71.3% of statements
ok      github.com/splunk/syntheticsclient/v2/syntheticsclientv2        2.483s  coverage: 71.3% of statements
```

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----
