### PR TITLE
SYN-4581: add optional timezone field, this is required for recurring…

### DIFF
--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -229,6 +229,7 @@ type DowntimeConfiguration struct {
 	Testcount      int         `json:"testCount,omitempty"`
 	Testids        []int       `json:"testIds,omitempty"`
 	Recurrence     *Recurrence `json:"recurrence"`
+	Timezone       *string     `json:"timezone,omitempty"`
 }
 
 type DeleteCheck struct {

--- a/syntheticsclientv2/create_downtimeconfigurationv2_test.go
+++ b/syntheticsclientv2/create_downtimeconfigurationv2_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	createDowntimeConfigurationV2Body = `{"downtimeConfiguration":{"name":"dc test","description":"My super awesome test downtimeConfiguration","rule":"augment_data","testIds":[482],"startTime":"2024-05-16T20:23:00.000Z","endTime":"2024-05-16T20:38:00.000Z","recurrence":{"repeats":{"type":"daily"},"end":{"type":"after","value":"10"}}}}`
+	createDowntimeConfigurationV2Body = `{"downtimeConfiguration":{"name":"dc test","description":"My super awesome test downtimeConfiguration","rule":"augment_data","testIds":[482],"startTime":"2024-05-16T20:23:00.000Z","endTime":"2024-05-16T20:38:00.000Z","timezone":"UTC","recurrence":{"repeats":{"type":"daily"},"end":{"type":"after","value":"10"}}}}`
 	inputDowntimeConfigurationV2Data  = DowntimeConfigurationV2Input{}
 )
 
@@ -81,6 +81,10 @@ func TestCreateDowntimeConfigurationV2(t *testing.T) {
 
 	if !reflect.DeepEqual(resp.DowntimeConfiguration.Recurrence, inputDowntimeConfigurationV2Data.DowntimeConfiguration.Recurrence) {
 		t.Errorf("returned \n\n%#v want \n\n%#v", resp.DowntimeConfiguration.Recurrence, inputDowntimeConfigurationV2Data.DowntimeConfiguration.Recurrence)
+	}
+
+	if !reflect.DeepEqual(resp.DowntimeConfiguration.Timezone, inputDowntimeConfigurationV2Data.DowntimeConfiguration.Timezone) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.DowntimeConfiguration.Timezone, inputDowntimeConfigurationV2Data.DowntimeConfiguration.Timezone)
 	}
 
 }

--- a/syntheticsclientv2/get_downtimeconfigurationsv2_test.go
+++ b/syntheticsclientv2/get_downtimeconfigurationsv2_test.go
@@ -27,9 +27,9 @@ import (
 var (
 	getDowntimeConfigurationsV2Body   = `{"page":1,"perPage":50}`
 	inputGetDowntimeConfigurationsV2  = verifyDowntimeConfigurationsV2Input(string(getDowntimeConfigurationsV2Body))
-	getDowntimeConfigurationsV2Output = `{"downtimeConfigurations":[{"id":1,"name":"dc test","description":"My super awesome test downtimeConfiguration","rule":"pause_tests","startTime":"2024-05-16T20:23:00.000Z","endTime":"2024-05-16T20:38:00.000Z","status":"scheduled","createdAt":"2024-05-15T20:24:07.541Z","updatedAt":"2024-05-15T20:25:44.211Z","testsUpdatedAt":"2024-05-15T20:24:07.541Z","testCount":1,"recurrence":{"repeats":{"type":"daily"},"end":{"type":"after","value":"10"}}}],"page":1,"pageLimit":1,"totalCount":1}`
+	getDowntimeConfigurationsV2Output = `{"downtimeConfigurations":[{"id":1,"name":"dc test","description":"My super awesome test downtimeConfiguration","rule":"pause_tests","startTime":"2024-05-16T20:23:00.000Z","endTime":"2024-05-16T20:38:00.000Z","status":"scheduled","createdAt":"2024-05-15T20:24:07.541Z","updatedAt":"2024-05-15T20:25:44.211Z","testsUpdatedAt":"2024-05-15T20:24:07.541Z","testCount":1,"timezone":"UTC","recurrence":{"repeats":{"type":"daily"},"end":{"type":"after","value":"10"}}}],"page":1,"pageLimit":1,"totalCount":1}`
 	downtimeConfigurationsV2Output    = &DowntimeConfigurationsV2Response{}
-	getDowntimeConfigurationV2Body    = `{"downtimeConfiguration":{"id":1,"name":"dc test","description":"My super awesome test downtimeConfiguration","rule":"pause_tests","startTime":"2024-05-16T20:23:00.000Z","endTime":"2024-05-16T20:38:00.000Z","status":"scheduled","createdAt":"2024-05-15T20:24:07.541Z","updatedAt":"2024-05-15T20:25:44.211Z","testsUpdatedAt":"2024-05-15T20:24:07.541Z","testIds":[29976],"recurrence":{"repeats":{"type":"daily"},"end":{"type":"after","value":"10"}}}}`
+	getDowntimeConfigurationV2Body    = `{"downtimeConfiguration":{"id":1,"name":"dc test","description":"My super awesome test downtimeConfiguration","rule":"pause_tests","startTime":"2024-05-16T20:23:00.000Z","endTime":"2024-05-16T20:38:00.000Z","status":"scheduled","createdAt":"2024-05-15T20:24:07.541Z","updatedAt":"2024-05-15T20:25:44.211Z","testsUpdatedAt":"2024-05-15T20:24:07.541Z","testIds":[29976],"timezone":"UTC","recurrence":{"repeats":{"type":"daily"},"end":{"type":"after","value":"10"}}}}`
 	inputGetDowntimeConfigurationV2   = verifyDowntimeConfigurationV2Input(string(getDowntimeConfigurationV2Body))
 )
 
@@ -92,6 +92,10 @@ func TestGetDowntimeConfigurationV2(t *testing.T) {
 
 	if !reflect.DeepEqual(resp.DowntimeConfiguration.Recurrence, inputGetDowntimeConfigurationV2.DowntimeConfiguration.Recurrence) {
 		t.Errorf("returned \n\n%#v want \n\n%#v", resp.DowntimeConfiguration.Recurrence, inputGetDowntimeConfigurationV2.DowntimeConfiguration.Recurrence)
+	}
+
+	if !reflect.DeepEqual(resp.DowntimeConfiguration.Timezone, inputGetDowntimeConfigurationV2.DowntimeConfiguration.Timezone) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.DowntimeConfiguration.Timezone, inputGetDowntimeConfigurationV2.DowntimeConfiguration.Timezone)
 	}
 
 }


### PR DESCRIPTION
… downtime configurations

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* add timezone field, this is required for recurring downtime configurations

### Pull request checklist 
- [x] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
<!-- Please paste the results of acceptance tests `make testacc` in the codeblock here. -->
```
➜  syntheticsclient git:(SYN-4581_add_tz) ✗ make test
==> Fixing source code with gofmt 
gofmt -s -w .
==> Checking source code against linters 
==> Running all tests
go test ./syntheticsclientv2/... -v -tags=unit_tests -timeout=30s -parallel=4 -cover
=== RUN   TestCreateApiCheckV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53874
************
POST /tests/api HTTP/1.1
Host: 127.0.0.1:53874
User-Agent: Go-http-client/1.1
Content-Length: 720
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{"test":{"active":true,"deviceId":0,"frequency":5,"locationIds":null,"name":"boop-test","requests":[{"configuration":{"body":"","headers":{"X-SF-TOKEN":"jinglebellsbatmanshells","beep":"boop"},"name":"Get-Test","requestMethod":"GET","url":"https://api.us1.signalfx.com/v2/synthetics/tests/api/489"},"setup":[{"extractor":"$.requests","name":"Extract from response body","source":"{{response.body}}","type":"extract_json","variable":"custom-varz"}],"validations":[{"actual":"{{response.code}}","comparator":"equals","expected":"200","name":"Assert response code equals 200","type":"assert_numeric"}]}],"schedulingStrategy":"","customProperties":[{"key":"Test_Key","value":"Test Custom Properties"}],"automaticRetries":1}}
************
&{{true 0001-01-01 00:00:00 +0000 UTC {0   { 0 0 0 0} 0 0} 5 0 [] boop-test [{{ map[X-SF-TOKEN:jinglebellsbatmanshells beep:boop] Get-Test GET https://api.us1.signalfx.com/v2/synthetics/tests/api/489} [{$.requests Extract from response body {{response.body}} extract_json custom-varz  }] [{{{response.code}} equals 200  Assert response code equals 200  assert_numeric   }]}]   0001-01-01 00:00:00 +0000 UTC [{Test_Key Test Custom Properties}]  0001-01-01 00:00:00 +0000 UTC 1  }}
--- PASS: TestCreateApiCheckV2 (0.00s)
=== RUN   TestCreateBrowserCheckV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53876
************
POST /tests/browser HTTP/1.1
Host: 127.0.0.1:53876
User-Agent: Go-http-client/1.1
Content-Length: 2438
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{"test":{"name":"browser-beep-test","transactions":[{"name":"Synthetic transaction 1","steps":[{"name":"Go to URL","type":"go_to_url","url":"https://splunk.com","action":"go_to_url","waitForNav":false,"options":{"url":"https://splunk.com"}},{"name":"click","type":"click_element","waitForNav":true,"waitForNavTimeout":2000,"selectorType":"id","selector":"clicky","options":{}},{"name":"fill in fieldz","type":"enter_value","waitForNav":false,"waitForNavTimeout":50,"selectorType":"id","selector":"beep","value":"{{env.beep-var}}","options":{}},{"name":"accept---Alert","type":"accept_alert","waitForNav":false,"options":{}},{"name":"Select-Val-Index","type":"select_option","waitForNav":false,"waitForNavTimeout":50,"selectorType":"id","selector":"selectionz","optionSelectorType":"index","optionSelector":"{{env.beep-var}}","options":{}},{"name":"Select-val-text","type":"select_option","waitForNav":false,"waitForNavTimeout":50,"selectorType":"id","selector":"textzz","optionSelectorType":"text","optionSelector":"sdad","options":{}},{"name":"Select-Val-Val","type":"select_option","waitForNav":false,"waitForNavTimeout":50,"selectorType":"id","selector":"valz","optionSelectorType":"value","optionSelector":"{{env.beep-var}}","options":{}},{"name":"Run JS","type":"run_javascript","waitForNav":true,"waitForNavTimeout":2000,"value":"beeeeeeep","options":{}},{"name":"Save as text","type":"store_variable_from_element","waitForNav":false,"selectorType":"link","selector":"beepval","variableName":"{{env.terraform-test-foo-301}}","options":{}},{"name":"Save JS return Val","type":"store_variable_from_javascript","waitForNav":true,"waitForNavTimeout":2000,"variableName":"{{env.terraform-test-foo-301}}","value":"sdasds","options":{}}]}],"urlProtocol":"https://","startUrl":"www.splunk.com","locationIds":["aws-us-east-1"],"deviceId":1,"frequency":5,"schedulingStrategy":"round_robin","active":true,"advancedSettings":{"authentication":{"password":"{{env.beep-var}}","username":"boopuser"},"cookies":[{"key":"super","value":"duper","domain":"www.batmansagent.com","path":"/boom/goes/beep"}],"headers":[{"name":"batman","value":"Agentoz","domain":"www.batmansagent.com"}],"hostOverrides":null,"userAgent":null,"collectInteractiveMetrics":false,"verifyCertificates":true,"chromeFlags":[{"name":"--proxy-bypass-list","value":"127.0.0.1:8080"}]},"customProperties":[{"key":"Test_Key","value":"Test Custom Properties"}],"automaticRetries":1}}
************
&{{true {0xc0001464e0 [{super duper www.batmansagent.com /boom/goes/beep}] [{batman Agentoz www.batmansagent.com}] [] <nil> false true [{--proxy-bypass-list 127.0.0.1:8080}]} 0001-01-01 00:00:00 +0000 UTC {0   { 0 0 0 0} 0 0} 5 0 [aws-us-east-1] browser-beep-test round_robin [{Synthetic transaction 1 [{Go to URL go_to_url https://splunk.com go_to_url false 0 false 0 false       {https://splunk.com} 0} {click click_element   true 2000 false 0 false id clicky     {} 0} {fill in fieldz enter_value   false 50 false 0 false id beep    {{env.beep-var}} {} 0} {accept---Alert accept_alert   false 0 false 0 false       {} 0} {Select-Val-Index select_option   false 50 false 0 false id selectionz index {{env.beep-var}}   {} 0} {Select-val-text select_option   false 50 false 0 false id textzz text sdad   {} 0} {Select-Val-Val select_option   false 50 false 0 false id valz value {{env.beep-var}}   {} 0} {Run JS run_javascript   true 2000 false 0 false      beeeeeeep {} 0} {Save as text store_variable_from_element   false 0 false 0 false link beepval   {{env.terraform-test-foo-301}}  {} 0} {Save JS return Val store_variable_from_javascript   true 2000 false 0 false     {{env.terraform-test-foo-301}} sdasds {} 0}]}]  0001-01-01 00:00:00 +0000 UTC [{Test_Key Test Custom Properties}]  0001-01-01 00:00:00 +0000 UTC 1  }}
--- PASS: TestCreateBrowserCheckV2 (0.00s)
=== RUN   TestCreateDowntimeConfigurationV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53878
************
POST /downtime_configurations HTTP/1.1
Host: 127.0.0.1:53878
User-Agent: Go-http-client/1.1
Content-Length: 457
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{"downtimeConfiguration":{"createdAt":"0001-01-01T00:00:00Z","description":"My super awesome test downtimeConfiguration","name":"dc test","updatedAt":"0001-01-01T00:00:00Z","rule":"augment_data","startTime":"2024-05-16T20:23:00Z","endTime":"2024-05-16T20:38:00Z","testsUpdatedAt":"0001-01-01T00:00:00Z","testIds":[482],"recurrence":{"repeats":{"type":"daily","customValue":null,"customFrequency":null},"end":{"type":"after","value":"10"}},"timezone":"UTC"}}
************
&{{0001-01-01 00:00:00 +0000 UTC My super awesome test downtimeConfiguration 0 dc test 0001-01-01 00:00:00 +0000 UTC augment_data 2024-05-16 20:23:00 +0000 UTC 2024-05-16 20:38:00 +0000 UTC  0001-01-01 00:00:00 +0000 UTC 0 [482] 0xc0000a2900 0xc0000a02e0}}
--- PASS: TestCreateDowntimeConfigurationV2 (0.00s)
=== RUN   TestCreateHttpCheckV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53880
************
POST /tests/http HTTP/1.1
Host: 127.0.0.1:53880
User-Agent: Go-http-client/1.1
Content-Length: 401
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{"test":{"name":"morebeeps-test","type":"http","url":"https://www.splunk.com","locationIds":null,"frequency":10,"schedulingStrategy":"","active":true,"requestMethod":"","authentication":null,"userAgent":null,"verifyCertificates":false,"headers":[{"name":"boop","value":"beep"}],"validations":[],"customProperties":[{"key":"Test_Key","value":"Test Custom Properties"}],"automaticRetries":1,"port":443}}
************
&{{0 morebeeps-test true 10  0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC [] http https://www.splunk.com   <nil> <nil> false [{boop beep}] [] [{Test_Key Test Custom Properties}]  0001-01-01 00:00:00 +0000 UTC 1 443  }}
--- PASS: TestCreateHttpCheckV2 (0.00s)
=== RUN   TestCreateLocationV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53882
************
POST /locations HTTP/1.1
Host: 127.0.0.1:53882
User-Agent: Go-http-client/1.1
Content-Length: 79
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{"location":{"id":"private-data-center","label":"Data Center","default":false}}
************
&{{private-data-center Data Center false  } {[] []}}
--- PASS: TestCreateLocationV2 (0.00s)
=== RUN   TestCreatePortCheckV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53884
************
POST /tests/port HTTP/1.1
Host: 127.0.0.1:53884
User-Agent: Go-http-client/1.1
Content-Length: 278
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{"test":{"name":"splunk - port 443","type":"port","url":"","port":443,"protocol":"tcp","host":"www.splunk.com","locationIds":null,"frequency":10,"schedulingStrategy":"","active":true,"customProperties":[{"key":"Test_Key","value":"Test Custom Properties"}],"automaticRetries":1}}
************
&{{0 splunk - port 443 true 10  0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC [] port tcp www.splunk.com 443 [{Test_Key Test Custom Properties}]  0001-01-01 00:00:00 +0000 UTC 1  }}
--- PASS: TestCreatePortCheckV2 (0.00s)
=== RUN   TestCreateVariableV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53886
************
POST /variables HTTP/1.1
Host: 127.0.0.1:53886
User-Agent: Go-http-client/1.1
Content-Length: 174
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{"variable":{"createdAt":"0001-01-01T00:00:00Z","description":"My super awesome test variable","name":"food","secret":false,"updatedAt":"0001-01-01T00:00:00Z","value":"bar"}}
************
&{{0001-01-01 00:00:00 +0000 UTC My super awesome test variable 0 food false 0001-01-01 00:00:00 +0000 UTC bar}}
--- PASS: TestCreateVariableV2 (0.00s)
=== RUN   TestDeleteApiCheckV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53888
************
DELETE /tests/api/19 HTTP/1.1
Host: 127.0.0.1:53888
User-Agent: Go-http-client/1.1
Content-Length: 2
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{}
************
200
200
--- PASS: TestDeleteApiCheckV2 (0.00s)
=== RUN   TestDeleteBrowserCheckV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53890
************
DELETE /tests/browser/19 HTTP/1.1
Host: 127.0.0.1:53890
User-Agent: Go-http-client/1.1
Content-Length: 2
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{}
************
200
200
--- PASS: TestDeleteBrowserCheckV2 (0.00s)
=== RUN   TestDeleteDowntimeConfigurationV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53892
************
DELETE /downtime_configurations/19 HTTP/1.1
Host: 127.0.0.1:53892
User-Agent: Go-http-client/1.1
Content-Length: 2
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{}
************
200
200
--- PASS: TestDeleteDowntimeConfigurationV2 (0.00s)
=== RUN   TestDeleteHttpCheckV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53894
************
DELETE /tests/http/19 HTTP/1.1
Host: 127.0.0.1:53894
User-Agent: Go-http-client/1.1
Content-Length: 2
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{}
************
200
200
--- PASS: TestDeleteHttpCheckV2 (0.00s)
=== RUN   TestDeleteLocationV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53896
************
DELETE /locations/beep HTTP/1.1
Host: 127.0.0.1:53896
User-Agent: Go-http-client/1.1
Content-Length: 2
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{}
************
200
200
--- PASS: TestDeleteLocationV2 (0.00s)
=== RUN   TestDeletePortCheckV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53898
************
DELETE /tests/port/19 HTTP/1.1
Host: 127.0.0.1:53898
User-Agent: Go-http-client/1.1
Content-Length: 2
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{}
************
200
200
--- PASS: TestDeletePortCheckV2 (0.00s)
=== RUN   TestDeleteVariableV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53900
************
DELETE /variables/19 HTTP/1.1
Host: 127.0.0.1:53900
User-Agent: Go-http-client/1.1
Content-Length: 2
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{}
************
200
200
--- PASS: TestDeleteVariableV2 (0.00s)
=== RUN   TestGetApiCheckV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53902
************
GET /tests/api/489 HTTP/1.1
Host: 127.0.0.1:53902
User-Agent: Go-http-client/1.1
Content-Length: 2
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{}
************
--- PASS: TestGetApiCheckV2 (0.00s)
=== RUN   TestGetBrowserCheckV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53904
************
GET /tests/browser/1 HTTP/1.1
Host: 127.0.0.1:53904
User-Agent: Go-http-client/1.1
Content-Length: 2
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{}
************
--- PASS: TestGetBrowserCheckV2 (0.00s)
=== RUN   TestGetChecksV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53906
************
GET /tests?orderBy=id&page=1&perPage=50&schedulingStrategy=&search=&testType= HTTP/1.1
Host: 127.0.0.1:53906
User-Agent: Go-http-client/1.1
Content-Length: 2
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{}
************
--- PASS: TestGetChecksV2 (0.00s)
=== RUN   TestGetDevicesV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53909
************
GET /devices HTTP/1.1
Host: 127.0.0.1:53909
User-Agent: Go-http-client/1.1
Content-Length: 2
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{}
************
--- PASS: TestGetDevicesV2 (0.00s)
=== RUN   TestGetDowntimeConfigurationV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53911
************
GET /downtime_configurations/1 HTTP/1.1
Host: 127.0.0.1:53911
User-Agent: Go-http-client/1.1
Content-Length: 2
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{}
************
--- PASS: TestGetDowntimeConfigurationV2 (0.00s)
=== RUN   TestGetDowntimeConfigurationsV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53913
************
GET /downtime_configurations?orderBy=&page=1&perPage=50&search= HTTP/1.1
Host: 127.0.0.1:53913
User-Agent: Go-http-client/1.1
Content-Length: 2
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{}
************
--- PASS: TestGetDowntimeConfigurationsV2 (0.00s)
=== RUN   TestGetHttpCheckV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53915
************
GET /tests/http/1 HTTP/1.1
Host: 127.0.0.1:53915
User-Agent: Go-http-client/1.1
Content-Length: 2
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{}
************
--- PASS: TestGetHttpCheckV2 (0.00s)
=== RUN   TestGetLocationsV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53917
************
GET /locations HTTP/1.1
Host: 127.0.0.1:53917
User-Agent: Go-http-client/1.1
Content-Length: 2
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{}
************
--- PASS: TestGetLocationsV2 (0.00s)
=== RUN   TestGetLocationV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53919
************
GET /locations/aws-us-east-1 HTTP/1.1
Host: 127.0.0.1:53919
User-Agent: Go-http-client/1.1
Content-Length: 2
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{}
************
--- PASS: TestGetLocationV2 (0.00s)
=== RUN   TestGetPortCheckV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53921
************
GET /tests/port/1 HTTP/1.1
Host: 127.0.0.1:53921
User-Agent: Go-http-client/1.1
Content-Length: 2
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{}
************
--- PASS: TestGetPortCheckV2 (0.00s)
=== RUN   TestGetVariableV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53923
************
GET /variables/1 HTTP/1.1
Host: 127.0.0.1:53923
User-Agent: Go-http-client/1.1
Content-Length: 2
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{}
************
--- PASS: TestGetVariableV2 (0.00s)
=== RUN   TestGetVariablesV2
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53925
************
GET /variables HTTP/1.1
Host: 127.0.0.1:53925
User-Agent: Go-http-client/1.1
Content-Length: 2
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{}
************
--- PASS: TestGetVariablesV2 (0.00s)
=== RUN   TestConfigurableClient
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53927
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53928
--- PASS: TestConfigurableClient (0.00s)
=== RUN   TestConfigurableClientTimeout
2025/03/06 14:11:14 Client instantiated: http://127.0.0.1:53929
************
GET /tests/browser/12 HTTP/1.1
Host: 127.0.0.1:53929
User-Agent: Go-http-client/1.1
Content-Length: 2
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{}
************
--- PASS: TestConfigurableClientTimeout (1.00s)
=== RUN   TestConfigurableClientErrorStatusCode
************
GET /tests HTTP/1.1
Host: 127.0.0.1:53935
User-Agent: Go-http-client/1.1
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip


************
--- PASS: TestConfigurableClientErrorStatusCode (0.00s)
=== RUN   TestUpdateApiCheckV2
2025/03/06 14:11:15 Client instantiated: http://127.0.0.1:53937
************
PUT /tests/api/10 HTTP/1.1
Host: 127.0.0.1:53937
User-Agent: Go-http-client/1.1
Content-Length: 720
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{"test":{"active":true,"deviceId":0,"frequency":5,"locationIds":null,"name":"boop-test","requests":[{"configuration":{"body":"","headers":{"X-SF-TOKEN":"jinglebellsbatmanshells","beep":"boop"},"name":"Get-Test","requestMethod":"GET","url":"https://api.us1.signalfx.com/v2/synthetics/tests/api/489"},"setup":[{"extractor":"$.requests","name":"Extract from response body","source":"{{response.body}}","type":"extract_json","variable":"custom-varz"}],"validations":[{"actual":"{{response.code}}","comparator":"equals","expected":"200","name":"Assert response code equals 200","type":"assert_numeric"}]}],"schedulingStrategy":"","customProperties":[{"key":"Test_Key","value":"Test Custom Properties"}],"automaticRetries":1}}
************
&{{true 0001-01-01 00:00:00 +0000 UTC {0   { 0 0 0 0} 0 0} 5 0 [] boop-test [{{ map[X-SF-TOKEN:jinglebellsbatmanshells beep:boop] Get-Test GET https://api.us1.signalfx.com/v2/synthetics/tests/api/489} [{$.requests Extract from response body {{response.body}} extract_json custom-varz  }] [{{{response.code}} equals 200  Assert response code equals 200  assert_numeric   }]}]   0001-01-01 00:00:00 +0000 UTC [{Test_Key Test Custom Properties}]  0001-01-01 00:00:00 +0000 UTC 1  }}
--- PASS: TestUpdateApiCheckV2 (0.00s)
=== RUN   TestUpdateBrowserCheckV2
2025/03/06 14:11:15 Client instantiated: http://127.0.0.1:53939
************
PUT /tests/browser/10 HTTP/1.1
Host: 127.0.0.1:53939
User-Agent: Go-http-client/1.1
Content-Length: 2439
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{"test":{"name":"browser-beep-test","transactions":[{"name":"Synthetic transaction 1","steps":[{"name":"Go to URL","type":"go_to_url","url":"https://splunk.com","action":"go_to_url","waitForNav":false,"options":{"url":"https://splunk.com"}},{"name":"click","type":"click_element","waitForNav":true,"waitForNavTimeout":2000,"selectorType":"id","selector":"clicky","options":{}},{"name":"fill in fieldz","type":"enter_value","waitForNav":false,"waitForNavTimeout":50,"selectorType":"id","selector":"beep","value":"{{env.beep-var}}","options":{}},{"name":"accept---Alert","type":"accept_alert","waitForNav":false,"options":{}},{"name":"Select-Val-Index","type":"select_option","waitForNav":false,"waitForNavTimeout":50,"selectorType":"id","selector":"selectionz","optionSelectorType":"index","optionSelector":"{{env.beep-var}}","options":{}},{"name":"Select-val-text","type":"select_option","waitForNav":false,"waitForNavTimeout":50,"selectorType":"id","selector":"textzz","optionSelectorType":"text","optionSelector":"sdad","options":{}},{"name":"Select-Val-Val","type":"select_option","waitForNav":false,"waitForNavTimeout":50,"selectorType":"id","selector":"valz","optionSelectorType":"value","optionSelector":"{{env.beep-var}}","options":{}},{"name":"Run JS","type":"run_javascript","waitForNav":true,"waitForNavTimeout":2000,"value":"beeeeeeep","options":{}},{"name":"Save as text","type":"store_variable_from_element","waitForNav":false,"selectorType":"link","selector":"beepval","variableName":"{{env.terraform-test-foo-301}}","options":{}},{"name":"Save JS return Val","type":"store_variable_from_javascript","waitForNav":true,"waitForNavTimeout":2000,"variableName":"{{env.terraform-test-foo-301}}","value":"sdasds","options":{}}]}],"urlProtocol":"https://","startUrl":"www.splunk.com","locationIds":["aws-us-east-1"],"deviceId":1,"frequency":15,"schedulingStrategy":"round_robin","active":true,"advancedSettings":{"authentication":{"password":"{{env.beep-var}}","username":"boopuser"},"cookies":[{"key":"super","value":"duper","domain":"www.batmansagent.com","path":"/boom/goes/beep"}],"headers":[{"name":"batman","value":"Agentoz","domain":"www.batmansagent.com"}],"hostOverrides":null,"userAgent":null,"collectInteractiveMetrics":false,"verifyCertificates":true,"chromeFlags":[{"name":"--proxy-bypass-list","value":"127.0.0.1:8080"}]},"customProperties":[{"key":"Test_Key","value":"Test Custom Properties"}],"automaticRetries":1}}
************
&{{true {0xc0004240e0 [{super duper www.batmansagent.com /boom/goes/beep}] [{batman Agentoz www.batmansagent.com}] [] <nil> false true [{--proxy-bypass-list 127.0.0.1:8080}]} 0001-01-01 00:00:00 +0000 UTC {0   { 0 0 0 0} 0 0} 15 0 [aws-us-east-1] browser-beep-test round_robin [{Synthetic transaction 1 [{Go to URL go_to_url https://splunk.com go_to_url false 0 false 0 false       {https://splunk.com} 0} {click click_element   true 2000 false 0 false id clicky     {} 0} {fill in fieldz enter_value   false 50 false 0 false id beep    {{env.beep-var}} {} 0} {accept---Alert accept_alert   false 0 false 0 false       {} 0} {Select-Val-Index select_option   false 50 false 0 false id selectionz index {{env.beep-var}}   {} 0} {Select-val-text select_option   false 50 false 0 false id textzz text sdad   {} 0} {Select-Val-Val select_option   false 50 false 0 false id valz value {{env.beep-var}}   {} 0} {Run JS run_javascript   true 2000 false 0 false      beeeeeeep {} 0} {Save as text store_variable_from_element   false 0 false 0 false link beepval   {{env.terraform-test-foo-301}}  {} 0} {Save JS return Val store_variable_from_javascript   true 2000 false 0 false     {{env.terraform-test-foo-301}} sdasds {} 0}]}]  0001-01-01 00:00:00 +0000 UTC [{Test_Key Test Custom Properties}]  0001-01-01 00:00:00 +0000 UTC 1  }}
--- PASS: TestUpdateBrowserCheckV2 (0.00s)
=== RUN   TestUpdateDowntimeConfigurationV2
2025/03/06 14:11:15 Client instantiated: http://127.0.0.1:53941
************
PUT /downtime_configurations/10 HTTP/1.1
Host: 127.0.0.1:53941
User-Agent: Go-http-client/1.1
Content-Length: 339
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{"downtimeConfiguration":{"createdAt":"0001-01-01T00:00:00Z","description":"My super awesome test downtimeConfiguration","name":"dc test","updatedAt":"0001-01-01T00:00:00Z","rule":"pause_tests","startTime":"2024-05-16T20:23:00Z","endTime":"2024-05-16T20:38:00Z","testsUpdatedAt":"0001-01-01T00:00:00Z","testIds":[29976],"recurrence":null}}
************
&{{0001-01-01 00:00:00 +0000 UTC My super awesome test downtimeConfiguration 0 dc test 0001-01-01 00:00:00 +0000 UTC pause_tests 2024-05-16 20:23:00 +0000 UTC 2024-05-16 20:38:00 +0000 UTC  0001-01-01 00:00:00 +0000 UTC 0 [29976] <nil> <nil>}}
--- PASS: TestUpdateDowntimeConfigurationV2 (0.00s)
=== RUN   TestUpdateHttpCheckV2
2025/03/06 14:11:15 Client instantiated: http://127.0.0.1:53943
************
PUT /tests/http/10 HTTP/1.1
Host: 127.0.0.1:53943
User-Agent: Go-http-client/1.1
Content-Length: 401
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{"test":{"name":"morebeeps-test","type":"http","url":"https://www.splunk.com","locationIds":null,"frequency":10,"schedulingStrategy":"","active":true,"requestMethod":"","authentication":null,"userAgent":null,"verifyCertificates":false,"headers":[{"name":"boop","value":"beep"}],"validations":[],"customProperties":[{"key":"Test_Key","value":"Test Custom Properties"}],"automaticRetries":1,"port":443}}
************
&{{0 morebeeps-test true 10  0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC [] http https://www.splunk.com   <nil> <nil> false [{boop beep}] [] [{Test_Key Test Custom Properties}]  0001-01-01 00:00:00 +0000 UTC 1 443  }}
--- PASS: TestUpdateHttpCheckV2 (0.00s)
=== RUN   TestUpdatePortCheckV2
2025/03/06 14:11:15 Client instantiated: http://127.0.0.1:53945
************
PUT /tests/port/1650 HTTP/1.1
Host: 127.0.0.1:53945
User-Agent: Go-http-client/1.1
Content-Length: 277
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{"test":{"name":"splunk - port 443","type":"port","url":"","port":80,"protocol":"tcp","host":"www.splunk.com","locationIds":null,"frequency":10,"schedulingStrategy":"","active":true,"customProperties":[{"key":"Test_Key","value":"Test Custom Properties"}],"automaticRetries":1}}
************
&{{0 splunk - port 443 true 10  0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC [] port tcp www.splunk.com 80 [{Test_Key Test Custom Properties}]  0001-01-01 00:00:00 +0000 UTC 1  }}
--- PASS: TestUpdatePortCheckV2 (0.00s)
=== RUN   TestUpdateVariableV2
2025/03/06 14:11:15 Client instantiated: http://127.0.0.1:53947
************
PUT /variables/10 HTTP/1.1
Host: 127.0.0.1:53947
User-Agent: Go-http-client/1.1
Content-Length: 174
Accept: application/json
Content-Type: application/json
X-Sf-Token: apiKey
Accept-Encoding: gzip

{"variable":{"createdAt":"0001-01-01T00:00:00Z","description":"My super awesome test variable","name":"foo2","secret":false,"updatedAt":"0001-01-01T00:00:00Z","value":"bar"}}
************
&{{0001-01-01 00:00:00 +0000 UTC My super awesome test variable 0 foo2 false 0001-01-01 00:00:00 +0000 UTC bar}}
--- PASS: TestUpdateVariableV2 (0.00s)
PASS
coverage: 71.3% of statements
ok      github.com/splunk/syntheticsclient/v2/syntheticsclientv2        1.752s  coverage: 71.3% of statements
```

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----
