### PR TITLE
Adding a new function to override the client args from terraform provider of synthetics

### DIFF
--- a/syntheticsclientv2/synthetics.go
+++ b/syntheticsclientv2/synthetics.go
@@ -121,6 +121,13 @@ func (c Client) makePublicAPICall(method string, endpoint string, requestBody io
 	return &details, nil
 }
 
+func NewClientArgs(timeout int, baseUrl string) ClientArgs {
+	return ClientArgs{
+		timeoutSeconds: timeout,
+		publicBaseUrl:  baseUrl,
+	}
+}
+
 func NewClient(apiKey string, realm string) *Client {
 	args := ClientArgs{timeoutSeconds: 30}
 	return NewConfigurableClient(apiKey, realm, args)


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->


----

### Before the change?
In one of our example, instead of using api.<REALM>.signalfx.com we are making use of external-api.<REALM>.signalfx.com api URL. So in order to achieve it, following support is added in which if apiUrl is passed in providers.tf, it will take precedence otherwise default one will be used.
In order to make that work in synthetics teraform provider, it is required to update the synthetics client code as well so that the non exportable variables can be set from Upstream.

* 

### After the change?
This is totally a new function in client code, so it will not affect the existing functionality in any way.

* 

### Pull request checklist 
- [ ] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
<!-- Please paste the results of acceptance tests `make testacc` in the codeblock here. -->
```

```

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----
