### PR TITLE
SYN-4842: excluded file types client

### DIFF
--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -117,6 +117,10 @@ type ChromeFlagsResponse struct {
 	ChromeFlags []ChromeFlag `json:"chromeFlags"`
 }
 
+type ExcludedFileTypesResponse struct {
+	ExcludedFileTypes []string `json:"excludedFileTypes"`
+}
+
 type Authentication struct {
 	Password string `json:"password,omitempty"`
 	Username string `json:"username,omitempty"`

--- a/syntheticsclientv2/get_excludedfiletypesv2.go
+++ b/syntheticsclientv2/get_excludedfiletypesv2.go
@@ -1,0 +1,48 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+func parseExcludedFileTypesV2Response(response string) (*ExcludedFileTypesResponse, error) {
+	var excludedFileTypes ExcludedFileTypesResponse
+	err := json.Unmarshal([]byte(response), &excludedFileTypes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &excludedFileTypes, err
+}
+
+func (c Client) GetExcludedFileTypesV2() (*ExcludedFileTypesResponse, *RequestDetails, error) {
+	details, err := c.makePublicAPICall("GET",
+		"/excluded_file_types",
+		bytes.NewBufferString("{}"),
+		nil)
+
+	if err != nil {
+		return nil, details, err
+	}
+
+	excludedFileTypes, err := parseExcludedFileTypesV2Response(details.ResponseBody)
+	if err != nil {
+		return excludedFileTypes, details, err
+	}
+
+	return excludedFileTypes, details, nil
+}

--- a/syntheticsclientv2/get_excludedfiletypesv2_test.go
+++ b/syntheticsclientv2/get_excludedfiletypesv2_test.go
@@ -1,0 +1,67 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var getExcludedFileTypesV2Body = `{"excludedFileTypes":["chartbeat","google_analytics"]}`
+
+func TestGetExcludedFileTypesV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/excluded_file_types", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		if r.URL.Path != "/excluded_file_types" {
+			t.Fatalf("path = %q, want /excluded_file_types", r.URL.Path)
+		}
+		_, err := w.Write([]byte(getExcludedFileTypesV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	resp, details, err := testClient.GetExcludedFileTypesV2()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if details.StatusCode != http.StatusOK {
+		t.Fatalf("status code = %d, want %d", details.StatusCode, http.StatusOK)
+	}
+
+	expected := []string{"chartbeat", "google_analytics"}
+	if !reflect.DeepEqual(resp.ExcludedFileTypes, expected) {
+		t.Fatalf("ExcludedFileTypes = %#v, want %#v", resp.ExcludedFileTypes, expected)
+	}
+}
+
+func TestParseExcludedFileTypesV2Response(t *testing.T) {
+	resp, err := parseExcludedFileTypesV2Response(getExcludedFileTypesV2Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []string{"chartbeat", "google_analytics"}
+	if !reflect.DeepEqual(resp.ExcludedFileTypes, expected) {
+		t.Fatalf("ExcludedFileTypes = %#v, want %#v", resp.ExcludedFileTypes, expected)
+	}
+}

--- a/syntheticsclientv2/synthetics.go
+++ b/syntheticsclientv2/synthetics.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httputil"
+	"strings"
 	"time"
 )
 
@@ -84,10 +85,7 @@ func (c Client) makePublicAPICall(method string, endpoint string, requestBody io
 	if err != nil {
 		return &details, err
 	}
-	details.RequestBody = string(requestDump)
-	fmt.Println("************")
-	fmt.Println(details.RequestBody)
-	fmt.Println("************")
+	details.RequestBody = redactSensitiveValue(string(requestDump), c.apiKey)
 
 	// Make the request
 	resp, err := c.httpClient.Do(req)
@@ -118,6 +116,14 @@ func (c Client) makePublicAPICall(method string, endpoint string, requestBody io
 	details.ResponseBody = string(responseBody)
 
 	return &details, nil
+}
+
+func redactSensitiveValue(value string, sensitiveValue string) string {
+	if sensitiveValue == "" {
+		return value
+	}
+
+	return strings.ReplaceAll(value, sensitiveValue, "[REDACTED]")
 }
 
 func NewClientArgs(timeout int, baseUrl string) ClientArgs {

--- a/syntheticsclientv2/synthetics_test.go
+++ b/syntheticsclientv2/synthetics_test.go
@@ -18,6 +18,7 @@
 package syntheticsclientv2
 
 import (
+	"bytes"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -119,5 +120,42 @@ func TestConfigurableClientErrorStatusCode(t *testing.T) {
 
 	if details.StatusCode != http.StatusNotFound {
 		t.Errorf("expected to see 404 status code, but saw: %d", details.StatusCode)
+	}
+}
+
+func TestMakePublicAPICallRedactsAPIKeyFromRequestDetails(t *testing.T) {
+	testMux = http.NewServeMux()
+	testServer = httptest.NewServer(testMux)
+	defer testServer.Close()
+
+	testMux.HandleFunc("/tests", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`))
+	})
+
+	apiKey := "secret-api-key"
+	testConfigurableClient := NewConfigurableClient(apiKey, "realm", ClientArgs{
+		publicBaseUrl: testServer.URL,
+	})
+
+	details, err := testConfigurableClient.makePublicAPICall("POST", "/tests", bytes.NewBufferString(`{"name":"test"}`), nil)
+	if err != nil {
+		t.Fatalf("expected no error, but saw: %s", err.Error())
+	}
+
+	if strings.Contains(details.RequestBody, apiKey) {
+		t.Fatalf("expected request details to redact API key, but found it in: %s", details.RequestBody)
+	}
+
+	if !strings.Contains(details.RequestBody, "[REDACTED]") {
+		t.Fatalf("expected request details to contain redaction marker, but saw: %s", details.RequestBody)
+	}
+}
+
+func TestRedactSensitiveValueIgnoresEmptyValue(t *testing.T) {
+	requestDump := "GET /tests HTTP/1.1\r\nX-Sf-Token: \r\n\r\n{}"
+
+	if got := redactSensitiveValue(requestDump, ""); got != requestDump {
+		t.Fatalf("expected empty sensitive value to leave request dump unchanged, but saw: %s", got)
 	}
 }


### PR DESCRIPTION
Resolves SYN-4842

----

### Before the change?

* `syntheticsclient/v2` had browser check model support for `excludedFiles`, but no client method to discover the API-owned excluded file types.
* `makePublicAPICall` printed full dumped requests to stdout after setting `X-SF-TOKEN`, which could expose API tokens in logs.

### After the change?

* Added `ExcludedFileTypesResponse`.
* Added `GetExcludedFileTypesV2()` for `GET /excluded_file_types`, parsing the public `excludedFileTypes` response field.
* Added unit coverage for the excluded file types client method and parser.
* Removed stdout request dumping from `makePublicAPICall`.
* Preserved `RequestDetails.RequestBody` compatibility while redacting the client API key before storing request details.

### Pull request checklist 
- [x] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features) - N/A: client SDK unit-only change.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output

N/A. This client SDK change is covered by unit tests.

```text
ok  	github.com/splunk/syntheticsclient/v2/syntheticsclientv2	1.359s
```

### Does this introduce a breaking change?

- [ ] Yes
- [x] No