### PR TITLE
SYN-3601: add nullable HTTP V2 port client methods

### DIFF
--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -587,6 +587,57 @@ type HttpCheckV2Input struct {
 	} `json:"test"`
 }
 
+type HttpCheckV2ResponseWithNullablePort struct {
+	Test struct {
+		ID                 int                `json:"id"`
+		Name               string             `json:"name"`
+		Active             bool               `json:"active"`
+		Frequency          int                `json:"frequency"`
+		SchedulingStrategy string             `json:"schedulingStrategy"`
+		CreatedAt          time.Time          `json:"createdAt,omitempty"`
+		UpdatedAt          time.Time          `json:"updatedAt,omitempty"`
+		LocationIds        []string           `json:"locationIds"`
+		Type               string             `json:"type"`
+		URL                string             `json:"url"`
+		RequestMethod      string             `json:"requestMethod"`
+		Body               string             `json:"body,omitempty"`
+		Authentication     *Authentication    `json:"authentication"`
+		UserAgent          *string            `json:"userAgent"`
+		Verifycertificates bool               `json:"verifyCertificates"`
+		HttpHeaders        []HttpHeaders      `json:"headers,omitempty"`
+		Validations        []Validations      `json:"validations"`
+		Customproperties   []CustomProperties `json:"customProperties"`
+		Lastrunstatus      string             `json:"lastRunStatus"`
+		Lastrunat          time.Time          `json:"lastRunAt"`
+		Automaticretries   int                `json:"automaticRetries"`
+		Port               NullableInt        `json:"port"`
+		Createdby          string             `json:"createdBy"`
+		Updatedby          string             `json:"updatedBy"`
+	} `json:"test"`
+}
+
+type HttpCheckV2InputWithNullablePort struct {
+	Test struct {
+		Name               string             `json:"name"`
+		Type               string             `json:"type"`
+		URL                string             `json:"url"`
+		LocationIds        []string           `json:"locationIds"`
+		Frequency          int                `json:"frequency"`
+		SchedulingStrategy string             `json:"schedulingStrategy"`
+		Active             bool               `json:"active"`
+		RequestMethod      string             `json:"requestMethod"`
+		Body               string             `json:"body,omitempty"`
+		Authentication     *Authentication    `json:"authentication"`
+		UserAgent          *string            `json:"userAgent"`
+		Verifycertificates bool               `json:"verifyCertificates"`
+		HttpHeaders        []HttpHeaders      `json:"headers,omitempty"`
+		Validations        []Validations      `json:"validations"`
+		Customproperties   []CustomProperties `json:"customProperties"`
+		Automaticretries   int                `json:"automaticRetries"`
+		Port               NullableInt        `json:"port"`
+	} `json:"test"`
+}
+
 type ApiCheckV2Input struct {
 	Test struct {
 		Active             bool               `json:"active"`

--- a/syntheticsclientv2/create_httpcheckv2.go
+++ b/syntheticsclientv2/create_httpcheckv2.go
@@ -55,3 +55,38 @@ func (c Client) CreateHttpCheckV2(HttpCheckV2Details *HttpCheckV2Input) (*HttpCh
 
 	return newHttpCheckV2, details, nil
 }
+
+func parseCreateHttpCheckV2WithNullablePortResponse(response string) (*HttpCheckV2ResponseWithNullablePort, error) {
+	var createHttpCheckV2 HttpCheckV2ResponseWithNullablePort
+	JSONResponse := []byte(response)
+	err := json.Unmarshal(JSONResponse, &createHttpCheckV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &createHttpCheckV2, err
+}
+
+func (c Client) CreateHttpCheckV2WithNullablePort(HttpCheckV2Details *HttpCheckV2InputWithNullablePort) (*HttpCheckV2ResponseWithNullablePort, *RequestDetails, error) {
+	if HttpCheckV2Details.Test.Validations == nil {
+		validation := make([]Validations, 0)
+		HttpCheckV2Details.Test.Validations = validation
+	}
+
+	body, err := json.Marshal(HttpCheckV2Details)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	details, err := c.makePublicAPICall("POST", "/tests/http", bytes.NewBuffer(body), nil)
+	if err != nil {
+		return nil, details, err
+	}
+
+	newHttpCheckV2, err := parseCreateHttpCheckV2WithNullablePortResponse(details.ResponseBody)
+	if err != nil {
+		return newHttpCheckV2, details, err
+	}
+
+	return newHttpCheckV2, details, nil
+}

--- a/syntheticsclientv2/get_httpcheckv2.go
+++ b/syntheticsclientv2/get_httpcheckv2.go
@@ -46,3 +46,27 @@ func (c Client) GetHttpCheckV2(id int) (*HttpCheckV2Response, *RequestDetails, e
 
 	return HttpCheckV2, details, nil
 }
+
+func parseGetHttpCheckV2WithNullablePortResponse(response string) (*HttpCheckV2ResponseWithNullablePort, error) {
+	var HttpCheckV2 HttpCheckV2ResponseWithNullablePort
+	err := json.Unmarshal([]byte(response), &HttpCheckV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &HttpCheckV2, err
+}
+
+func (c Client) GetHttpCheckV2WithNullablePort(id int) (*HttpCheckV2ResponseWithNullablePort, *RequestDetails, error) {
+	details, err := c.makePublicAPICall("GET", fmt.Sprintf("/tests/http/%d", id), bytes.NewBufferString("{}"), nil)
+	if err != nil {
+		return nil, details, err
+	}
+
+	HttpCheckV2, err := parseGetHttpCheckV2WithNullablePortResponse(details.ResponseBody)
+	if err != nil {
+		return HttpCheckV2, details, err
+	}
+
+	return HttpCheckV2, details, nil
+}

--- a/syntheticsclientv2/httpcheckv2_nullable_port_test.go
+++ b/syntheticsclientv2/httpcheckv2_nullable_port_test.go
@@ -1,0 +1,180 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestCreateHttpCheckV2WithNullablePortSendsNullPort(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests/http", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		fields := readHttpV2NullablePortRequestFields(t, r)
+		rawPort, ok := fields["port"]
+		if !ok {
+			t.Fatal("request body missing test.port")
+		}
+		if string(rawPort) != "null" {
+			t.Fatalf("request body test.port = %s, want null", rawPort)
+		}
+		_, err := w.Write([]byte(`{"test":{"id":11,"name":"nullable-port","type":"http","url":"https://example.com","requestMethod":"GET","port":null}}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	input := minimalHttpCheckV2InputWithNullablePort()
+	input.Test.Port = *NewNullInt()
+
+	resp, _, err := testClient.CreateHttpCheckV2WithNullablePort(&input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Test.Port.Value != nil {
+		t.Fatalf("response port = %#v, want nil", resp.Test.Port.Value)
+	}
+}
+
+func TestUpdateHttpCheckV2WithNullablePortSendsZeroPort(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests/http/12", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		fields := readHttpV2NullablePortRequestFields(t, r)
+		rawPort, ok := fields["port"]
+		if !ok {
+			t.Fatal("request body missing test.port")
+		}
+		if string(rawPort) != "0" {
+			t.Fatalf("request body test.port = %s, want 0", rawPort)
+		}
+		_, err := w.Write([]byte(`{"test":{"id":12,"name":"nullable-port","type":"http","url":"https://example.com","requestMethod":"GET","port":0}}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	input := minimalHttpCheckV2InputWithNullablePort()
+	input.Test.Port = *NewNullableInt(0)
+
+	resp, _, err := testClient.UpdateHttpCheckV2WithNullablePort(12, &input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Test.Port.Value == nil || *resp.Test.Port.Value != 0 {
+		t.Fatalf("response port = %#v, want 0", resp.Test.Port.Value)
+	}
+}
+
+func TestGetHttpCheckV2WithNullablePortPreservesNullAndValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantNil   bool
+		wantValue int
+	}{
+		{
+			name:    "null",
+			body:    `{"test":{"id":13,"name":"nullable-port","type":"http","url":"https://example.com","requestMethod":"GET","port":null}}`,
+			wantNil: true,
+		},
+		{
+			name:      "value",
+			body:      `{"test":{"id":13,"name":"nullable-port","type":"http","url":"https://example.com","requestMethod":"GET","port":443}}`,
+			wantValue: 443,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup()
+			defer teardown()
+
+			testMux.HandleFunc("/tests/http/13", func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, "GET")
+				_, err := w.Write([]byte(tt.body))
+				if err != nil {
+					t.Fatal(err)
+				}
+			})
+
+			resp, _, err := testClient.GetHttpCheckV2WithNullablePort(13)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tt.wantNil {
+				if resp.Test.Port.Value != nil {
+					t.Fatalf("response port = %#v, want nil", resp.Test.Port.Value)
+				}
+				return
+			}
+			if resp.Test.Port.Value == nil || *resp.Test.Port.Value != tt.wantValue {
+				t.Fatalf("response port = %#v, want %d", resp.Test.Port.Value, tt.wantValue)
+			}
+		})
+	}
+}
+
+func minimalHttpCheckV2InputWithNullablePort() HttpCheckV2InputWithNullablePort {
+	input := HttpCheckV2InputWithNullablePort{}
+	input.Test.Name = "nullable-port"
+	input.Test.Type = "http"
+	input.Test.URL = "https://example.com"
+	input.Test.LocationIds = []string{"aws-us-east-1"}
+	input.Test.Frequency = 5
+	input.Test.SchedulingStrategy = "round_robin"
+	input.Test.Active = true
+	input.Test.RequestMethod = "GET"
+	input.Test.Verifycertificates = true
+	input.Test.Validations = []Validations{}
+	input.Test.Customproperties = []CustomProperties{}
+	return input
+}
+
+func readHttpV2NullablePortRequestFields(t *testing.T, r *http.Request) map[string]json.RawMessage {
+	t.Helper()
+
+	requestBody, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(requestBody, &envelope); err != nil {
+		t.Fatalf("request body JSON parse failed: %v", err)
+	}
+
+	rawTest, ok := envelope["test"]
+	if !ok {
+		t.Fatalf("request body missing test envelope: %s", requestBody)
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(rawTest, &fields); err != nil {
+		t.Fatalf("request body test JSON parse failed: %v", err)
+	}
+
+	return fields
+}

--- a/syntheticsclientv2/update_httpcheckv2.go
+++ b/syntheticsclientv2/update_httpcheckv2.go
@@ -55,3 +55,39 @@ func (c Client) UpdateHttpCheckV2(id int, HttpCheckV2Details *HttpCheckV2Input) 
 
 	return updateHttpCheckV2, requestDetails, nil
 }
+
+func parseUpdateHttpCheckV2WithNullablePortResponse(response string) (*HttpCheckV2ResponseWithNullablePort, error) {
+	var updateHttpCheckV2 HttpCheckV2ResponseWithNullablePort
+	if response != "" {
+		err := json.Unmarshal([]byte(response), &updateHttpCheckV2)
+		if err != nil {
+			return nil, err
+		}
+		return &updateHttpCheckV2, err
+	}
+	return &updateHttpCheckV2, nil
+}
+
+func (c Client) UpdateHttpCheckV2WithNullablePort(id int, HttpCheckV2Details *HttpCheckV2InputWithNullablePort) (*HttpCheckV2ResponseWithNullablePort, *RequestDetails, error) {
+	if HttpCheckV2Details.Test.Validations == nil {
+		validation := make([]Validations, 0)
+		HttpCheckV2Details.Test.Validations = validation
+	}
+
+	body, err := json.Marshal(HttpCheckV2Details)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	requestDetails, err := c.makePublicAPICall("PUT", fmt.Sprintf("/tests/http/%d", id), bytes.NewBuffer(body), nil)
+	if err != nil {
+		return nil, requestDetails, err
+	}
+
+	updateHttpCheckV2, err := parseUpdateHttpCheckV2WithNullablePortResponse(requestDetails.ResponseBody)
+	if err != nil {
+		return updateHttpCheckV2, requestDetails, err
+	}
+
+	return updateHttpCheckV2, requestDetails, nil
+}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* HTTP V2 check client models use `int` for `port`, so API responses cannot distinguish an omitted/null port from `0`.
* Existing `CreateHttpCheckV2`, `UpdateHttpCheckV2`, and `GetHttpCheckV2` methods expose only the non-nullable HTTP V2 types.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Adds additive HTTP V2 nullable-port models using the existing `NullableInt` helper.
* Adds nullable-port create, update, and get methods:
  * `CreateHttpCheckV2WithNullablePort`
  * `UpdateHttpCheckV2WithNullablePort`
  * `GetHttpCheckV2WithNullablePort`
* Preserves compatibility by leaving existing HTTP V2 models and methods unchanged.
* Allows downstream consumers, including the Terraform provider, to preserve `null`, `0`, and normal port values correctly.

### Pull request checklist 
- [x] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
<!-- Please paste the results of acceptance tests `make testacc` in the codeblock here. -->

```text
PASS
coverage: 71.5% of statements
ok  	github.com/splunk/syntheticsclient/v2/syntheticsclientv2	1.519s	coverage: 71.5% of statements
```

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----
