### PR TITLE
SYN-5402: client certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ func main() {
 ## API Documentation
 API Docs are [available here](https://dev.splunk.com/observability/reference)
 
+## Request Details
+
+V2 methods return `RequestDetails` for debugging failed or unexpected API calls.
+Use `RequestDetails.RequestBody` when you need to inspect the outgoing request.
+This field is sanitized before it is returned and redacts API tokens, certificate
+content, passwords, and generic secret values.
+
+`RequestDetails.RawRequest` is intentionally not populated by V2 public API calls
+because a raw `http.Request` can retain authorization headers or request body
+secrets.
+
 ## Additional Information
 This client is largely a copypasta mutation of the [go-victor](https://github.com/victorops/go-victorops) client for Splunk On-Call (formerly known as VictorOps).
 

--- a/syntheticsclientv2/clientcertificate_models_test.go
+++ b/syntheticsclientv2/clientcertificate_models_test.go
@@ -1,0 +1,108 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestClientCertificateV2InputUsesPublicJSONCasing(t *testing.T) {
+	payload := ClientCertificateV2Input{
+		Certificate: ClientCertificateInput{
+			Name:        "mtls_api_example",
+			Description: "mTLS certificate for api.example.com",
+			Domain:      "api.example.com",
+			PublicKey: ClientCertificateKeyInput{
+				Content:       "base64-public",
+				Filename:      "client.crt",
+				FileExtension: "pem",
+			},
+			PrivateKey: ClientCertificatePrivateKeyInput{
+				Content:       "base64-private",
+				Filename:      "client.key",
+				FileExtension: "pem",
+				Password:      "key-password",
+			},
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jsonBody := string(body)
+
+	for _, field := range []string{`"certificate"`, `"publicKey"`, `"privateKey"`, `"fileExtension"`, `"password"`} {
+		if !strings.Contains(jsonBody, field) {
+			t.Fatalf("request body missing %s: %s", field, jsonBody)
+		}
+	}
+	for _, field := range []string{"public_key", "private_key", "file_extension", "fileName"} {
+		if strings.Contains(jsonBody, field) {
+			t.Fatalf("request body contains internal field %s: %s", field, jsonBody)
+		}
+	}
+}
+
+func TestClientCertificateV2ResponseParsesPublicJSONCasing(t *testing.T) {
+	body := `{
+		"certificate": {
+			"id": 123,
+			"name": "mtls_api_example",
+			"description": "mTLS certificate for api.example.com",
+			"domain": "api.example.com",
+			"expiresAt": "2027-01-02T03:04:05Z",
+			"createdAt": "2026-01-02T03:04:05Z",
+			"createdBy": "boris@example.com",
+			"updatedAt": "2026-01-03T03:04:05Z",
+			"updatedBy": "boris@example.com",
+			"publicKey": {
+				"id": 501,
+				"content": "<REDACTED>",
+				"filename": "client.crt",
+				"fileExtension": "pem"
+			},
+			"privateKey": {
+				"id": 502,
+				"content": "<REDACTED>",
+				"filename": "client.key",
+				"fileExtension": "pem",
+				"password": "<REDACTED>"
+			}
+		}
+	}`
+
+	var response ClientCertificateV2Response
+	if err := json.NewDecoder(strings.NewReader(body)).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Certificate.ID != 123 {
+		t.Fatalf("certificate id %d want 123", response.Certificate.ID)
+	}
+	if expiresAt := response.Certificate.ExpiresAt.Format("2006-01-02T15:04:05Z"); expiresAt != "2027-01-02T03:04:05Z" {
+		t.Fatalf("expiresAt %s want 2027-01-02T03:04:05Z", expiresAt)
+	}
+	if response.Certificate.PublicKey.Content != "<REDACTED>" {
+		t.Fatalf("public key content %s want <REDACTED>", response.Certificate.PublicKey.Content)
+	}
+	if response.Certificate.PrivateKey.Password != "<REDACTED>" {
+		t.Fatalf("private key password %s want <REDACTED>", response.Certificate.PrivateKey.Password)
+	}
+}

--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -479,6 +479,87 @@ type CaCertificatesV2Response struct {
 	CaCerts []CaCertificate `json:"cacerts"`
 }
 
+type ClientCertificateKey struct {
+	ID            int       `json:"id,omitempty"`
+	Content       string    `json:"content,omitempty"`
+	Filename      string    `json:"filename,omitempty"`
+	FileExtension string    `json:"fileExtension,omitempty"`
+	CreatedAt     time.Time `json:"createdAt,omitempty"`
+	CreatedBy     string    `json:"createdBy,omitempty"`
+	UpdatedAt     time.Time `json:"updatedAt,omitempty"`
+	UpdatedBy     string    `json:"updatedBy,omitempty"`
+}
+
+type ClientCertificatePrivateKey struct {
+	ID            int       `json:"id,omitempty"`
+	Content       string    `json:"content,omitempty"`
+	Filename      string    `json:"filename,omitempty"`
+	FileExtension string    `json:"fileExtension,omitempty"`
+	Password      string    `json:"password,omitempty"`
+	CreatedAt     time.Time `json:"createdAt,omitempty"`
+	CreatedBy     string    `json:"createdBy,omitempty"`
+	UpdatedAt     time.Time `json:"updatedAt,omitempty"`
+	UpdatedBy     string    `json:"updatedBy,omitempty"`
+}
+
+type ClientCertificateKeyInput struct {
+	Content       string `json:"content"`
+	Filename      string `json:"filename"`
+	FileExtension string `json:"fileExtension"`
+}
+
+type ClientCertificatePrivateKeyInput struct {
+	Content       string `json:"content"`
+	Filename      string `json:"filename"`
+	FileExtension string `json:"fileExtension"`
+	Password      string `json:"password,omitempty"`
+}
+
+type ClientCertificate struct {
+	ID          int                         `json:"id,omitempty"`
+	Name        string                      `json:"name,omitempty"`
+	Description string                      `json:"description,omitempty"`
+	Domain      string                      `json:"domain,omitempty"`
+	ExpiresAt   time.Time                   `json:"expiresAt,omitempty"`
+	CreatedAt   time.Time                   `json:"createdAt,omitempty"`
+	CreatedBy   string                      `json:"createdBy,omitempty"`
+	UpdatedAt   time.Time                   `json:"updatedAt,omitempty"`
+	UpdatedBy   string                      `json:"updatedBy,omitempty"`
+	PublicKey   ClientCertificateKey        `json:"publicKey,omitempty"`
+	PrivateKey  ClientCertificatePrivateKey `json:"privateKey,omitempty"`
+}
+
+type ClientCertificateInput struct {
+	Name        string                           `json:"name"`
+	Description string                           `json:"description,omitempty"`
+	Domain      string                           `json:"domain"`
+	PublicKey   ClientCertificateKeyInput        `json:"publicKey"`
+	PrivateKey  ClientCertificatePrivateKeyInput `json:"privateKey"`
+}
+
+type ClientCertificateUpdateInput struct {
+	Description *string                           `json:"description,omitempty"`
+	Domain      *string                           `json:"domain,omitempty"`
+	PublicKey   *ClientCertificateKeyInput        `json:"publicKey,omitempty"`
+	PrivateKey  *ClientCertificatePrivateKeyInput `json:"privateKey,omitempty"`
+}
+
+type ClientCertificateV2Input struct {
+	Certificate ClientCertificateInput `json:"certificate"`
+}
+
+type ClientCertificateV2UpdateInput struct {
+	Certificate ClientCertificateUpdateInput `json:"certificate"`
+}
+
+type ClientCertificateV2Response struct {
+	Certificate ClientCertificate `json:"certificate"`
+}
+
+type ClientCertificatesV2Response struct {
+	Certificates []ClientCertificate `json:"certificates"`
+}
+
 type SslCheckV2Response struct {
 	Test struct {
 		ID                            int                `json:"id,omitempty"`

--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -106,6 +106,7 @@ type Advancedsettings struct {
 	Verifycertificates        bool             `json:"verifyCertificates"`
 	ChromeFlags               []ChromeFlag     `json:"chromeFlags"`
 	ExcludedFiles             []ExcludedFile   `json:"excludedFiles"`
+	CertificateIDs            []int            `json:"certificateIds,omitempty"`
 }
 
 type ChromeFlag struct {
@@ -207,9 +208,10 @@ type Requests struct {
 type Configuration struct {
 	Body          string `json:"body"`
 	Headers       `json:"headers"`
-	Name          string `json:"name"`
-	RequestMethod string `json:"requestMethod,omitempty"`
-	URL           string `json:"url,omitempty"`
+	Name          string       `json:"name"`
+	RequestMethod string       `json:"requestMethod,omitempty"`
+	URL           string       `json:"url,omitempty"`
+	CertificateID *NullableInt `json:"certificateId,omitempty"`
 }
 
 type Headers map[string]interface{}
@@ -685,6 +687,7 @@ type HttpCheckV2Response struct {
 		Authentication     *Authentication    `json:"authentication"`
 		UserAgent          *string            `json:"userAgent"`
 		Verifycertificates bool               `json:"verifyCertificates"`
+		CertificateID      *NullableInt       `json:"certificateId,omitempty"`
 		HttpHeaders        []HttpHeaders      `json:"headers,omitempty"`
 		Validations        []Validations      `json:"validations"`
 		Customproperties   []CustomProperties `json:"customProperties"`
@@ -711,6 +714,7 @@ type HttpCheckV2Input struct {
 		Authentication     *Authentication    `json:"authentication"`
 		UserAgent          *string            `json:"userAgent"`
 		Verifycertificates bool               `json:"verifyCertificates"`
+		CertificateID      *NullableInt       `json:"certificateId,omitempty"`
 		HttpHeaders        []HttpHeaders      `json:"headers,omitempty"`
 		Validations        []Validations      `json:"validations"`
 		Customproperties   []CustomProperties `json:"customProperties"`

--- a/syntheticsclientv2/create_apicheckv2_test.go
+++ b/syntheticsclientv2/create_apicheckv2_test.go
@@ -19,14 +19,15 @@ package syntheticsclientv2
 
 import (
 	"encoding/json"
-	"fmt"
+	"io"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 )
 
 var (
-	createApiV2Body = `{"test":{"automaticRetries": 1,"customProperties": [{"key": "Test_Key", "value": "Test Custom Properties"}], "active":true,"deviceId":1,"frequency":5,"location_ids":["aws-us-east-1"],"name":"boop-test","scheduling_strategy":"round_robin","requests":[{"configuration":{"name":"Get-Test","requestMethod":"GET","url":"https://api.us1.signalfx.com/v2/synthetics/v2/tests/api/489","headers":{"X-SF-TOKEN":"jinglebellsbatmanshells", "beep":"boop"},"body":null},"setup":[{"name":"Extract from response body","type":"extract_json","source":"{{response.body}}","extractor":"$.requests","variable":"custom-varz"}],"validations":[{"name":"Assert response code equals 200","type":"assert_numeric","actual":"{{response.code}}","expected":"200","comparator":"equals"}]}]}}`
+	createApiV2Body = `{"test":{"automaticRetries": 1,"customProperties": [{"key": "Test_Key", "value": "Test Custom Properties"}], "active":true,"deviceId":1,"frequency":5,"location_ids":["aws-us-east-1"],"name":"boop-test","scheduling_strategy":"round_robin","requests":[{"configuration":{"name":"Get-Test","requestMethod":"GET","url":"https://api.us1.signalfx.com/v2/synthetics/v2/tests/api/489","certificateId":123,"headers":{"X-SF-TOKEN":"jinglebellsbatmanshells", "beep":"boop"},"body":null},"setup":[{"name":"Extract from response body","type":"extract_json","source":"{{response.body}}","extractor":"$.requests","variable":"custom-varz"}],"validations":[{"name":"Assert response code equals 200","type":"assert_numeric","actual":"{{response.code}}","expected":"200","comparator":"equals"}]}]}}`
 	inputData       = ApiCheckV2Input{}
 )
 
@@ -36,7 +37,17 @@ func TestCreateApiCheckV2(t *testing.T) {
 
 	testMux.HandleFunc("/v2/tests/api", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		_, err := w.Write([]byte(createApiV2Body))
+		requestBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(requestBody), `"certificateId":123`) {
+			t.Fatalf("request body missing certificateId: %s", requestBody)
+		}
+		if strings.Contains(string(requestBody), "certificate_id") {
+			t.Fatalf("request body contains internal certificate_id field: %s", requestBody)
+		}
+		_, err = w.Write([]byte(createApiV2Body))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -52,8 +63,6 @@ func TestCreateApiCheckV2(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	fmt.Println(resp)
 
 	if !reflect.DeepEqual(resp.Test.Name, inputData.Test.Name) {
 		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Name, inputData.Test.Name)

--- a/syntheticsclientv2/create_browsercheckv2_test.go
+++ b/syntheticsclientv2/create_browsercheckv2_test.go
@@ -19,14 +19,15 @@ package syntheticsclientv2
 
 import (
 	"encoding/json"
-	"fmt"
+	"io"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 )
 
 var (
-	createBrowserCheckV2Body = `{"test":{"automaticRetries": 1, "customProperties": [{"key": "Test_Key", "value": "Test Custom Properties"}], "name":"browser-beep-test","transactions":[{"name":"Synthetic transaction 1","steps":[{"name":"Go to URL","type":"go_to_url","url":"https://splunk.com","action":"go_to_url","options":{"url":"https://splunk.com"}},{"name":"click","type":"click_element","selectors":[{"type":"id","value":"clicky"}],"waitForNav":true,"waitForNavTimeout":2000},{"name":"fill in fieldz","type":"enter_value","selectors":[{"type":"id","value":"beep"}],"value":"{{env.beep-var}}","waitForNav":false,"waitForNavTimeout":50},{"name":"accept---Alert","type":"accept_alert"},{"name":"Select-Val-Index","type":"select_option","selectors":[{"type":"id","value":"selectionz"}],"optionSelectorType":"index","optionSelector":"{{env.beep-var}}","waitForNav":false,"waitForNavTimeout":50},{"name":"Select-val-text","type":"select_option","selectors":[{"type":"id","value":"textzz"}],"optionSelectorType":"text","optionSelector":"sdad","waitForNav":false,"waitForNavTimeout":50},{"name":"Select-Val-Val","type":"select_option","selectors":[{"type":"id","value":"valz"}],"optionSelectorType":"value","optionSelector":"{{env.beep-var}}","waitForNav":false,"waitForNavTimeout":50},{"name":"Run JS","type":"run_javascript","value":"beeeeeeep","waitForNav":true,"waitForNavTimeout":2000},{"name":"Save as text","type":"store_variable_from_element","selectors":[{"type":"link","value":"beepval"}],"variableName":"{{env.terraform-test-foo-301}}"},{"name":"Save JS return Val","type":"store_variable_from_javascript","value":"sdasds","variableName":"{{env.terraform-test-foo-301}}","waitForNav":true,"waitForNavTimeout":2000}]}],"urlProtocol":"https://","startUrl":"www.splunk.com","locationIds":["aws-us-east-1"],"deviceId":1,"frequency":5,"schedulingStrategy":"round_robin","active":true,"advancedSettings":{"verifyCertificates":true,"authentication":{"username":"boopuser","password":"{{env.beep-var}}"},"headers":[{"name":"batman","value":"Agentoz","domain":"www.batmansagent.com"}],"chromeFlags":[{"name":"--proxy-bypass-list","value":"127.0.0.1:8080"}],"cookies":[{"key":"super","value":"duper","domain":"www.batmansagent.com","path":"/boom/goes/beep"}],"excludedFiles":[{"type":"google_analytics"},{"type":"custom","regex":"some-domain.com"},{"type":"all_except","regex":"another-domain.com"}]}}}`
+	createBrowserCheckV2Body = `{"test":{"automaticRetries": 1, "customProperties": [{"key": "Test_Key", "value": "Test Custom Properties"}], "name":"browser-beep-test","transactions":[{"name":"Synthetic transaction 1","steps":[{"name":"Go to URL","type":"go_to_url","url":"https://splunk.com","action":"go_to_url","options":{"url":"https://splunk.com"}},{"name":"click","type":"click_element","selectors":[{"type":"id","value":"clicky"}],"waitForNav":true,"waitForNavTimeout":2000},{"name":"fill in fieldz","type":"enter_value","selectors":[{"type":"id","value":"beep"}],"value":"{{env.beep-var}}","waitForNav":false,"waitForNavTimeout":50},{"name":"accept---Alert","type":"accept_alert"},{"name":"Select-Val-Index","type":"select_option","selectors":[{"type":"id","value":"selectionz"}],"optionSelectorType":"index","optionSelector":"{{env.beep-var}}","waitForNav":false,"waitForNavTimeout":50},{"name":"Select-val-text","type":"select_option","selectors":[{"type":"id","value":"textzz"}],"optionSelectorType":"text","optionSelector":"sdad","waitForNav":false,"waitForNavTimeout":50},{"name":"Select-Val-Val","type":"select_option","selectors":[{"type":"id","value":"valz"}],"optionSelectorType":"value","optionSelector":"{{env.beep-var}}","waitForNav":false,"waitForNavTimeout":50},{"name":"Run JS","type":"run_javascript","value":"beeeeeeep","waitForNav":true,"waitForNavTimeout":2000},{"name":"Save as text","type":"store_variable_from_element","selectors":[{"type":"link","value":"beepval"}],"variableName":"{{env.terraform-test-foo-301}}"},{"name":"Save JS return Val","type":"store_variable_from_javascript","value":"sdasds","variableName":"{{env.terraform-test-foo-301}}","waitForNav":true,"waitForNavTimeout":2000}]}],"urlProtocol":"https://","startUrl":"www.splunk.com","locationIds":["aws-us-east-1"],"deviceId":1,"frequency":5,"schedulingStrategy":"round_robin","active":true,"advancedSettings":{"verifyCertificates":true,"certificateIds":[123],"authentication":{"username":"boopuser","password":"{{env.beep-var}}"},"headers":[{"name":"batman","value":"Agentoz","domain":"www.batmansagent.com"}],"chromeFlags":[{"name":"--proxy-bypass-list","value":"127.0.0.1:8080"}],"cookies":[{"key":"super","value":"duper","domain":"www.batmansagent.com","path":"/boom/goes/beep"}],"excludedFiles":[{"type":"google_analytics"},{"type":"custom","regex":"some-domain.com"},{"type":"all_except","regex":"another-domain.com"}]}}}`
 	inputBrowserCheckV2Data  = BrowserCheckV2Input{}
 )
 
@@ -36,7 +37,17 @@ func TestCreateBrowserCheckV2(t *testing.T) {
 
 	testMux.HandleFunc("/v2/tests/browser", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		_, err := w.Write([]byte(createBrowserCheckV2Body))
+		requestBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(requestBody), `"certificateIds":[123]`) {
+			t.Fatalf("request body missing certificateIds: %s", requestBody)
+		}
+		if strings.Contains(string(requestBody), "certificate_ids") {
+			t.Fatalf("request body contains internal certificate_ids field: %s", requestBody)
+		}
+		_, err = w.Write([]byte(createBrowserCheckV2Body))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -52,8 +63,6 @@ func TestCreateBrowserCheckV2(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	fmt.Println(resp)
 
 	if !reflect.DeepEqual(resp.Test.Name, inputBrowserCheckV2Data.Test.Name) {
 		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Name, inputBrowserCheckV2Data.Test.Name)

--- a/syntheticsclientv2/create_clientcertificatev2.go
+++ b/syntheticsclientv2/create_clientcertificatev2.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+func parseCreateClientCertificateV2Response(response string) (*ClientCertificateV2Response, error) {
+	var createClientCertificateV2 ClientCertificateV2Response
+	err := json.Unmarshal([]byte(response), &createClientCertificateV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &createClientCertificateV2, nil
+}
+
+func (c Client) CreateClientCertificateV2(input *ClientCertificateV2Input) (*ClientCertificateV2Response, *RequestDetails, error) {
+	body, err := json.Marshal(input)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	details, err := c.makePublicAPICall("POST", "/certificates", bytes.NewBuffer(body), nil)
+	if err != nil {
+		return nil, details, err
+	}
+
+	newClientCertificateV2, err := parseCreateClientCertificateV2Response(details.ResponseBody)
+	if err != nil {
+		return newClientCertificateV2, details, err
+	}
+
+	return newClientCertificateV2, details, nil
+}

--- a/syntheticsclientv2/create_clientcertificatev2_test.go
+++ b/syntheticsclientv2/create_clientcertificatev2_test.go
@@ -1,0 +1,116 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var (
+	createClientCertificateV2Body         = `{"certificate":{"name":"mtls_api_example","description":"mTLS certificate","domain":"api.example.com","publicKey":{"content":"base64-public","fileExtension":"pem","filename":"client.crt"},"privateKey":{"content":"base64-private","fileExtension":"pem","filename":"client.key","password":"key-password"}}}`
+	createClientCertificateV2ResponseBody = `{"certificate":{"id":123,"name":"mtls_api_example","description":"mTLS certificate","domain":"api.example.com","expiresAt":"2027-01-02T03:04:05Z","createdAt":"2026-01-02T03:04:05Z","createdBy":"boris@example.com","updatedAt":"2026-01-03T03:04:05Z","updatedBy":"boris@example.com","publicKey":{"id":501,"content":"<REDACTED>","filename":"client.crt","fileExtension":"pem"},"privateKey":{"id":502,"content":"<REDACTED>","filename":"client.key","fileExtension":"pem","password":"<REDACTED>"}}}`
+	inputClientCertificateV2Data          = ClientCertificateV2Input{}
+	outputClientCertificateV2Data         = ClientCertificateV2Response{}
+)
+
+func TestCreateClientCertificateV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/certificates", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+
+		requestBody, requestCertificateFields := readClientCertificateRequestFields(t, r)
+
+		writableFields := []string{"name", "description", "domain", "publicKey", "privateKey"}
+		if len(requestCertificateFields) != len(writableFields) {
+			t.Errorf("request body certificate field count %d want %d: %s", len(requestCertificateFields), len(writableFields), requestBody)
+		}
+		for _, field := range writableFields {
+			if _, ok := requestCertificateFields[field]; !ok {
+				t.Errorf("request body missing certificate.%s", field)
+			}
+		}
+		for _, field := range []string{"id", "expiresAt", "createdAt", "createdBy", "updatedAt", "updatedBy", "public_key", "private_key", "file_extension"} {
+			if _, ok := requestCertificateFields[field]; ok {
+				t.Errorf("request body includes invalid certificate.%s", field)
+			}
+		}
+
+		requestClientCertificateV2Data := ClientCertificateV2Input{}
+		if err := json.Unmarshal(requestBody, &requestClientCertificateV2Data); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(requestClientCertificateV2Data.Certificate, inputClientCertificateV2Data.Certificate) {
+			t.Errorf("request body certificate \n\n%#v want \n\n%#v", requestClientCertificateV2Data.Certificate, inputClientCertificateV2Data.Certificate)
+		}
+
+		_, err := w.Write([]byte(createClientCertificateV2ResponseBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if err := json.Unmarshal([]byte(createClientCertificateV2Body), &inputClientCertificateV2Data); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(createClientCertificateV2ResponseBody), &outputClientCertificateV2Data); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, _, err := testClient.CreateClientCertificateV2(&inputClientCertificateV2Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(resp.Certificate, outputClientCertificateV2Data.Certificate) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Certificate, outputClientCertificateV2Data.Certificate)
+	}
+}
+
+func readClientCertificateRequestFields(t *testing.T, r *http.Request) ([]byte, map[string]json.RawMessage) {
+	t.Helper()
+
+	requestBody, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var requestEnvelope map[string]json.RawMessage
+	if err := json.Unmarshal(requestBody, &requestEnvelope); err != nil {
+		t.Fatal(err)
+	}
+	if len(requestEnvelope) != 1 {
+		t.Fatalf("request body envelope keys %#v want only certificate", requestEnvelope)
+	}
+	rawCertificate, ok := requestEnvelope["certificate"]
+	if !ok {
+		t.Fatal("request body missing certificate envelope")
+	}
+
+	var requestCertificateFields map[string]json.RawMessage
+	if err := json.Unmarshal(rawCertificate, &requestCertificateFields); err != nil {
+		t.Fatal(err)
+	}
+
+	return requestBody, requestCertificateFields
+}

--- a/syntheticsclientv2/create_httpcheckv2_test.go
+++ b/syntheticsclientv2/create_httpcheckv2_test.go
@@ -19,9 +19,10 @@ package syntheticsclientv2
 
 import (
 	"encoding/json"
-	"fmt"
+	"io"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -36,7 +37,17 @@ func TestCreateHttpCheckV2(t *testing.T) {
 
 	testMux.HandleFunc("/tests/http", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		_, err := w.Write([]byte(createHttpCheckV2Body))
+		requestBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(requestBody), `"certificateId":123`) {
+			t.Fatalf("request body missing certificateId: %s", requestBody)
+		}
+		if strings.Contains(string(requestBody), "certificate_id") {
+			t.Fatalf("request body contains internal certificate_id field: %s", requestBody)
+		}
+		_, err = w.Write([]byte(createHttpCheckV2Body))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -46,14 +57,13 @@ func TestCreateHttpCheckV2(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputHttpCheckV2Data.Test.CertificateID = NewNullableInt(123)
 
 	resp, _, err := testClient.CreateHttpCheckV2(&inputHttpCheckV2Data)
 
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	fmt.Println(resp)
 
 	if !reflect.DeepEqual(resp.Test.Name, inputHttpCheckV2Data.Test.Name) {
 		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Name, inputHttpCheckV2Data.Test.Name)

--- a/syntheticsclientv2/delete_clientcertificatev2.go
+++ b/syntheticsclientv2/delete_clientcertificatev2.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+func (c Client) DeleteClientCertificateV2(id int) (int, error) {
+	details, err := c.makePublicAPICall("DELETE", fmt.Sprintf("/certificates/%d", id), bytes.NewBufferString("{}"), nil)
+	if err != nil {
+		return 1, err
+	}
+
+	status := details.StatusCode
+	if status >= 300 || status < 200 {
+		errorMsg := fmt.Sprintf("error: Response code %v. Expecting 2XX.", strconv.Itoa(status))
+		return status, errors.New(errorMsg)
+	}
+
+	return status, nil
+}

--- a/syntheticsclientv2/delete_clientcertificatev2_test.go
+++ b/syntheticsclientv2/delete_clientcertificatev2_test.go
@@ -1,0 +1,41 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestDeleteClientCertificateV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/certificates/123", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	resp, err := testClient.DeleteClientCertificateV2(123)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != http.StatusNoContent {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, http.StatusNoContent)
+	}
+}

--- a/syntheticsclientv2/get_clientcertificatesv2.go
+++ b/syntheticsclientv2/get_clientcertificatesv2.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+func parseGetClientCertificatesV2Response(response string) (*ClientCertificatesV2Response, error) {
+	var clientCertificatesV2 ClientCertificatesV2Response
+	err := json.Unmarshal([]byte(response), &clientCertificatesV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clientCertificatesV2, nil
+}
+
+func (c Client) GetClientCertificatesV2() (*ClientCertificatesV2Response, *RequestDetails, error) {
+	details, err := c.makePublicAPICall("GET", "/certificates", bytes.NewBufferString("{}"), nil)
+	if err != nil {
+		return nil, details, err
+	}
+
+	clientCertificatesV2, err := parseGetClientCertificatesV2Response(details.ResponseBody)
+	if err != nil {
+		return clientCertificatesV2, details, err
+	}
+
+	return clientCertificatesV2, details, nil
+}

--- a/syntheticsclientv2/get_clientcertificatesv2_test.go
+++ b/syntheticsclientv2/get_clientcertificatesv2_test.go
@@ -1,0 +1,60 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var (
+	getClientCertificatesV2Body  = `{"certificates":[{"id":123,"name":"mtls_api_example","description":"mTLS certificate","domain":"api.example.com","expiresAt":"2027-01-02T03:04:05Z","createdAt":"2026-01-02T03:04:05Z","createdBy":"boris@example.com","updatedAt":"2026-01-03T03:04:05Z","updatedBy":"boris@example.com"},{"id":124,"name":"mtls_other_example","description":"Other mTLS certificate","domain":"other.example.com","expiresAt":"2027-02-02T03:04:05Z","createdAt":"2026-01-02T03:04:05Z","createdBy":"boris@example.com","updatedAt":"2026-01-03T03:04:05Z","updatedBy":"boris@example.com"}]}`
+	inputGetClientCertificatesV2 = verifyClientCertificatesV2Input(getClientCertificatesV2Body)
+)
+
+func TestGetClientCertificatesV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/certificates", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		_, err := w.Write([]byte(getClientCertificatesV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	resp, _, err := testClient.GetClientCertificatesV2()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(resp.Certificates, inputGetClientCertificatesV2.Certificates) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Certificates, inputGetClientCertificatesV2.Certificates)
+	}
+}
+
+func verifyClientCertificatesV2Input(stringInput string) *ClientCertificatesV2Response {
+	check := &ClientCertificatesV2Response{}
+	if err := json.Unmarshal([]byte(stringInput), check); err != nil {
+		panic(err)
+	}
+	return check
+}

--- a/syntheticsclientv2/get_clientcertificatev2.go
+++ b/syntheticsclientv2/get_clientcertificatev2.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func parseGetClientCertificateV2Response(response string) (*ClientCertificateV2Response, error) {
+	var clientCertificateV2 ClientCertificateV2Response
+	err := json.Unmarshal([]byte(response), &clientCertificateV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clientCertificateV2, nil
+}
+
+func (c Client) GetClientCertificateV2(id int) (*ClientCertificateV2Response, *RequestDetails, error) {
+	details, err := c.makePublicAPICall("GET", fmt.Sprintf("/certificates/%d", id), bytes.NewBufferString("{}"), nil)
+	if err != nil {
+		return nil, details, err
+	}
+
+	clientCertificateV2, err := parseGetClientCertificateV2Response(details.ResponseBody)
+	if err != nil {
+		return clientCertificateV2, details, err
+	}
+
+	return clientCertificateV2, details, nil
+}

--- a/syntheticsclientv2/get_clientcertificatev2_test.go
+++ b/syntheticsclientv2/get_clientcertificatev2_test.go
@@ -1,0 +1,60 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var (
+	getClientCertificateV2Body  = `{"certificate":{"id":123,"name":"mtls_api_example","description":"mTLS certificate","domain":"api.example.com","expiresAt":"2027-01-02T03:04:05Z","createdAt":"2026-01-02T03:04:05Z","createdBy":"boris@example.com","updatedAt":"2026-01-03T03:04:05Z","updatedBy":"boris@example.com","publicKey":{"id":501,"content":"<REDACTED>","filename":"client.crt","fileExtension":"pem"},"privateKey":{"id":502,"content":"<REDACTED>","filename":"client.key","fileExtension":"pem","password":"<REDACTED>"}}}`
+	inputGetClientCertificateV2 = verifyClientCertificateV2Input(getClientCertificateV2Body)
+)
+
+func TestGetClientCertificateV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/certificates/123", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		_, err := w.Write([]byte(getClientCertificateV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	resp, _, err := testClient.GetClientCertificateV2(123)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(resp.Certificate, inputGetClientCertificateV2.Certificate) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Certificate, inputGetClientCertificateV2.Certificate)
+	}
+}
+
+func verifyClientCertificateV2Input(stringInput string) *ClientCertificateV2Response {
+	check := &ClientCertificateV2Response{}
+	if err := json.Unmarshal([]byte(stringInput), check); err != nil {
+		panic(err)
+	}
+	return check
+}

--- a/syntheticsclientv2/synthetics.go
+++ b/syntheticsclientv2/synthetics.go
@@ -40,9 +40,13 @@ type ClientArgs struct {
 type RequestDetails struct {
 	StatusCode   int
 	ResponseBody string
-	RequestBody  string
-	RawResponse  *http.Response
-	RawRequest   *http.Request
+	// RequestBody is the supported debug representation of the outgoing request.
+	// It redacts API tokens and sensitive JSON values before being returned.
+	RequestBody string
+	RawResponse *http.Response
+	// RawRequest is intentionally not returned by v2 public API calls because it
+	// can retain authorization headers or request body secrets.
+	RawRequest *http.Request
 }
 
 type errorResponse struct {
@@ -85,8 +89,6 @@ func (c Client) makePublicAPICall(method string, endpoint string, requestBody io
 	}
 	req.URL.RawQuery = q.Encode()
 
-	// Add the request to the details
-	details.RawRequest = req
 	requestDump, err := httputil.DumpRequestOut(req, true)
 	if err != nil {
 		return &details, err

--- a/syntheticsclientv2/synthetics.go
+++ b/syntheticsclientv2/synthetics.go
@@ -58,6 +58,12 @@ func (c Client) String() string {
 	return fmt.Sprintf("Splunk Synthetics Client: URL: %s ", c.publicBaseURL)
 }
 
+var sensitiveJSONFieldNames = map[string]struct{}{
+	"content":  {},
+	"password": {},
+	"value":    {},
+}
+
 func (c Client) makePublicAPICall(method string, endpoint string, requestBody io.Reader, queryParams map[string]string) (*RequestDetails, error) {
 	details := RequestDetails{}
 	// Create the request
@@ -126,18 +132,14 @@ func redactSensitiveValue(value string, sensitiveValue string) string {
 	return strings.ReplaceAll(value, sensitiveValue, "[REDACTED]")
 }
 
-func sanitizeRequestDump(requestDump string, apiKey string, endpoint string) string {
+func sanitizeRequestDump(requestDump string, apiKey string, _ string) string {
 	sanitizedRequestDump := redactSensitiveValue(requestDump, apiKey)
-	if !strings.Contains(endpoint, "/cacerts") {
-		return sanitizedRequestDump
-	}
-
-	return redactCaCertificateContent(sanitizedRequestDump)
+	return redactSensitiveRequestBody(sanitizedRequestDump)
 }
 
-func redactCaCertificateContent(requestDump string) string {
+func redactSensitiveRequestBody(requestDump string) string {
 	headers, body, separator, ok := splitRequestDump(requestDump)
-	if !ok || body == "" {
+	if !ok || strings.TrimSpace(body) == "" {
 		return requestDump
 	}
 
@@ -146,7 +148,7 @@ func redactCaCertificateContent(requestDump string) string {
 		return replaceRequestDumpBody(headers, separator)
 	}
 
-	redactContentFields(requestBody)
+	redactSensitiveJSONFields(requestBody)
 
 	redactedRequestBody, err := json.Marshal(requestBody)
 	if err != nil {
@@ -171,19 +173,19 @@ func replaceRequestDumpBody(headers string, separator string) string {
 	return headers + separator + "[REDACTED]"
 }
 
-func redactContentFields(value interface{}) {
+func redactSensitiveJSONFields(value interface{}) {
 	switch typedValue := value.(type) {
 	case map[string]interface{}:
 		for key, nestedValue := range typedValue {
-			if strings.EqualFold(key, "content") {
+			if _, ok := sensitiveJSONFieldNames[strings.ToLower(key)]; ok {
 				typedValue[key] = "[REDACTED]"
 				continue
 			}
-			redactContentFields(nestedValue)
+			redactSensitiveJSONFields(nestedValue)
 		}
 	case []interface{}:
 		for _, nestedValue := range typedValue {
-			redactContentFields(nestedValue)
+			redactSensitiveJSONFields(nestedValue)
 		}
 	}
 }

--- a/syntheticsclientv2/synthetics_test.go
+++ b/syntheticsclientv2/synthetics_test.go
@@ -278,3 +278,39 @@ func TestRedactSensitiveValueIgnoresEmptyValue(t *testing.T) {
 		t.Fatalf("expected empty sensitive value to leave request dump unchanged, but saw: %s", got)
 	}
 }
+
+func TestSanitizeRequestDumpRedactsHeadersAndSecretJSONFields(t *testing.T) {
+	requestDump := "POST /certificates HTTP/1.1\r\nX-SF-TOKEN: token-123\r\nContent-Type: application/json\r\n\r\n" +
+		`{"certificate":{"publicKey":{"content":"public-secret"},"privateKey":{"content":"private-secret","password":"password-secret"}}}`
+
+	sanitized := sanitizeRequestDump(requestDump, "token-123", "/certificates")
+
+	for _, secret := range []string{"token-123", "public-secret", "private-secret", "password-secret"} {
+		if strings.Contains(sanitized, secret) {
+			t.Fatalf("sanitized request dump leaked %q: %s", secret, sanitized)
+		}
+	}
+	for _, redacted := range []string{`"content":"[REDACTED]"`, `"password":"[REDACTED]"`, "X-SF-TOKEN: [REDACTED]"} {
+		if !strings.Contains(sanitized, redacted) {
+			t.Fatalf("sanitized request dump missing %q: %s", redacted, sanitized)
+		}
+	}
+}
+
+func TestSanitizeRequestDumpRedactsHeaderCookieAndAuthenticationValues(t *testing.T) {
+	requestDump := "PUT /tests/browser/123 HTTP/1.1\r\nX-Sf-Token: token-abc\r\n\r\n" +
+		`{"test":{"advancedSettings":{"headers":[{"name":"Authorization","value":"Bearer secret"}],"cookies":[{"name":"session","value":"cookie-secret"}],"authentication":{"password":"auth-secret"}}}}`
+
+	sanitized := sanitizeRequestDump(requestDump, "token-abc", "/tests/browser/123")
+
+	for _, secret := range []string{"token-abc", "Bearer secret", "cookie-secret", "auth-secret"} {
+		if strings.Contains(sanitized, secret) {
+			t.Fatalf("sanitized request dump leaked %q: %s", secret, sanitized)
+		}
+	}
+	for _, redacted := range []string{`"value":"[REDACTED]"`, `"password":"[REDACTED]"`, "X-Sf-Token: [REDACTED]"} {
+		if !strings.Contains(sanitized, redacted) {
+			t.Fatalf("sanitized request dump missing %q: %s", redacted, sanitized)
+		}
+	}
+}

--- a/syntheticsclientv2/synthetics_test.go
+++ b/syntheticsclientv2/synthetics_test.go
@@ -314,3 +314,39 @@ func TestSanitizeRequestDumpRedactsHeaderCookieAndAuthenticationValues(t *testin
 		}
 	}
 }
+
+func TestMakePublicAPICallDoesNotExposeRawRequest(t *testing.T) {
+	testMux = http.NewServeMux()
+	testServer = httptest.NewServer(testMux)
+	defer testServer.Close()
+
+	testMux.HandleFunc("/certificates", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`))
+	})
+
+	apiKey := "secret-api-key"
+	certificateContent := "private-certificate-material"
+	testConfigurableClient := NewConfigurableClient(apiKey, "realm", ClientArgs{
+		publicBaseUrl: testServer.URL,
+	})
+
+	requestBody := `{"certificate":{"publicKey":{"content":"` + certificateContent + `"}}}`
+	details, err := testConfigurableClient.makePublicAPICall("POST", "/certificates", bytes.NewBufferString(requestBody), nil)
+	if err != nil {
+		t.Fatalf("expected no error, but saw: %s", err.Error())
+	}
+
+	if details.RawRequest != nil {
+		t.Fatal("expected RawRequest to be nil; RequestBody is the supported sanitized debug representation")
+	}
+	if strings.Contains(details.RequestBody, apiKey) {
+		t.Fatalf("expected request details to redact API key, but found it in: %s", details.RequestBody)
+	}
+	if strings.Contains(details.RequestBody, certificateContent) {
+		t.Fatalf("expected request details to redact certificate content, but found it in: %s", details.RequestBody)
+	}
+	if !strings.Contains(details.RequestBody, `"content":"[REDACTED]"`) {
+		t.Fatalf("expected sanitized RequestBody to include redacted content field, but saw: %s", details.RequestBody)
+	}
+}

--- a/syntheticsclientv2/update_clientcertificatev2.go
+++ b/syntheticsclientv2/update_clientcertificatev2.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func parseUpdateClientCertificateV2Response(response string) (*ClientCertificateV2Response, error) {
+	var updateClientCertificateV2 ClientCertificateV2Response
+	if response != "" {
+		err := json.Unmarshal([]byte(response), &updateClientCertificateV2)
+		if err != nil {
+			return nil, err
+		}
+		return &updateClientCertificateV2, nil
+	}
+	return &updateClientCertificateV2, nil
+}
+
+func (c Client) UpdateClientCertificateV2(id int, input *ClientCertificateV2UpdateInput) (*ClientCertificateV2Response, *RequestDetails, error) {
+	body, err := json.Marshal(input)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	details, err := c.makePublicAPICall("PUT", fmt.Sprintf("/certificates/%d", id), bytes.NewBuffer(body), nil)
+	if err != nil {
+		return nil, details, err
+	}
+
+	updateClientCertificateV2, err := parseUpdateClientCertificateV2Response(details.ResponseBody)
+	if err != nil {
+		return updateClientCertificateV2, details, err
+	}
+
+	return updateClientCertificateV2, details, nil
+}

--- a/syntheticsclientv2/update_clientcertificatev2_test.go
+++ b/syntheticsclientv2/update_clientcertificatev2_test.go
@@ -1,0 +1,109 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+var (
+	updateClientCertificateV2Body  = `{"certificate":{"description":"updated certificate","domain":"api.example.com","publicKey":{"content":"base64-public","fileExtension":"pem","filename":"client.crt"},"privateKey":{"content":"base64-private","fileExtension":"pem","filename":"client.key","password":"key-password"}}}`
+	inputClientCertificateV2Update = ClientCertificateV2UpdateInput{}
+)
+
+func TestUpdateClientCertificateV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/certificates/123", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		assertClientCertificateUpdateRequestBody(t, r)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	if err := json.Unmarshal([]byte(updateClientCertificateV2Body), &inputClientCertificateV2Update); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, _, err := testClient.UpdateClientCertificateV2(123, &inputClientCertificateV2Update)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response for blank successful update body")
+	}
+}
+
+func TestUpdateClientCertificateV2DoesNotIncludeName(t *testing.T) {
+	setup()
+	defer teardown()
+
+	description := "updated certificate"
+	inputClientCertificateV2Update := ClientCertificateV2UpdateInput{}
+	inputClientCertificateV2Update.Certificate.Description = &description
+
+	testMux.HandleFunc("/certificates/124", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		_, requestCertificateFields := readClientCertificateRequestFields(t, r)
+		if _, ok := requestCertificateFields["name"]; ok {
+			t.Fatal("request body should not include certificate.name")
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	resp, _, err := testClient.UpdateClientCertificateV2(124, &inputClientCertificateV2Update)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response for blank successful update body")
+	}
+}
+
+func assertClientCertificateUpdateRequestBody(t *testing.T, r *http.Request) {
+	t.Helper()
+
+	requestBody, requestCertificateFields := readClientCertificateRequestFields(t, r)
+
+	expectedFields := map[string]string{
+		"description": `"updated certificate"`,
+		"domain":      `"api.example.com"`,
+		"publicKey":   `{"content":"base64-public","filename":"client.crt","fileExtension":"pem"}`,
+		"privateKey":  `{"content":"base64-private","filename":"client.key","fileExtension":"pem","password":"key-password"}`,
+	}
+	if len(requestCertificateFields) != len(expectedFields) {
+		t.Errorf("request body certificate field count %d want %d: %s", len(requestCertificateFields), len(expectedFields), requestBody)
+	}
+	for field, expected := range expectedFields {
+		rawValue, ok := requestCertificateFields[field]
+		if !ok {
+			t.Errorf("request body missing certificate.%s", field)
+			continue
+		}
+		if string(rawValue) != expected {
+			t.Errorf("request body certificate.%s %s want %s", field, rawValue, expected)
+		}
+	}
+	for _, field := range []string{"name", "id", "expiresAt", "createdAt", "createdBy", "updatedAt", "updatedBy"} {
+		if _, ok := requestCertificateFields[field]; ok {
+			t.Errorf("request body should not include certificate.%s", field)
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves #SYN-5402

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* syntheticsclient/v2 does not expose Synthetics client certificate CRUD APIs.
* HTTP V2, Browser V2, and API V2 client models do not expose client certificate attachment fields.
* Public request details can include raw API tokens, certificate content, passwords, header values, cookie values, or authentication values.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Adds public `ClientCertificate*` models using public API JSON casing.
* Adds create, get, list, update, and delete methods for `/certificates`.
* Adds HTTP `certificateId`, Browser `advancedSettings.certificateIds`, and API request `configuration.certificateId` model support.
* Redacts API token, `content`, `password`, and `value` fields from captured request details.
* Removes raw request dump printing from the public API client path.

### Pull request checklist 
- [x] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
<!-- Please paste the results of acceptance tests `make testacc` in the codeblock here. -->

```text
PASS
coverage: 71.8% of statements
ok github.com/splunk/syntheticsclient/v2/syntheticsclientv2
```

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----
