### PR TITLE
SYN-6665: MFA ToTP client

### DIFF
--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -299,6 +299,37 @@ type Variable struct {
 	Value       string    `json:"value"`
 }
 
+type TotpVariable struct {
+	CreatedAt   time.Time `json:"createdAt"`
+	CreatedBy   string    `json:"createdBy"`
+	Description string    `json:"description"`
+	Digits      int       `json:"digits"`
+	HmacDigest  string    `json:"hmacDigest"`
+	ID          int       `json:"id"`
+	Interval    int       `json:"interval"`
+	Name        string    `json:"name"`
+	Secret      string    `json:"secret"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+	UpdatedBy   string    `json:"updatedBy"`
+}
+
+type TotpVariableInput struct {
+	Description string `json:"description"`
+	Digits      int    `json:"digits"`
+	HmacDigest  string `json:"hmacDigest"`
+	Interval    int    `json:"interval"`
+	Name        string `json:"name"`
+	Secret      string `json:"secret"`
+}
+
+type TotpVariableUpdateInput struct {
+	Description *string `json:"description,omitempty"`
+	Digits      *int    `json:"digits,omitempty"`
+	HmacDigest  *string `json:"hmacDigest,omitempty"`
+	Interval    *int    `json:"interval,omitempty"`
+	Secret      *string `json:"secret,omitempty"`
+}
+
 type DowntimeConfiguration struct {
 	Createdat      time.Time   `json:"createdAt,omitempty"`
 	Description    string      `json:"description,omitempty"`
@@ -364,6 +395,22 @@ type VariableV2Input struct {
 
 type VariablesV2Response struct {
 	Variable []Variable `json:"variables"`
+}
+
+type TotpVariableV2Input struct {
+	Totp TotpVariableInput `json:"totp"`
+}
+
+type TotpVariableV2UpdateInput struct {
+	Totp TotpVariableUpdateInput `json:"totp"`
+}
+
+type TotpVariableV2Response struct {
+	Totp TotpVariable `json:"totp"`
+}
+
+type TotpVariablesV2Response struct {
+	Totps []TotpVariable `json:"totps"`
 }
 
 type LocationsV2Response struct {

--- a/syntheticsclientv2/create_totpvariablev2.go
+++ b/syntheticsclientv2/create_totpvariablev2.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+func parseCreateTotpVariableV2Response(response string) (*TotpVariableV2Response, error) {
+	var createTotpVariableV2 TotpVariableV2Response
+	err := json.Unmarshal([]byte(response), &createTotpVariableV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &createTotpVariableV2, err
+}
+
+func (c Client) CreateTotpVariableV2(TotpVariableV2Details *TotpVariableV2Input) (*TotpVariableV2Response, *RequestDetails, error) {
+	body, err := json.Marshal(TotpVariableV2Details)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	details, err := c.makePublicAPICall("POST", "/totps", bytes.NewBuffer(body), nil)
+	scrubTotpVariableRequestDetails(details, totpVariableCreateSecret(TotpVariableV2Details))
+	if err != nil {
+		return nil, details, err
+	}
+
+	newTotpVariableV2, err := parseCreateTotpVariableV2Response(details.ResponseBody)
+	if err != nil {
+		return newTotpVariableV2, details, err
+	}
+
+	return newTotpVariableV2, details, nil
+}
+
+func scrubTotpVariableRequestDetails(details *RequestDetails, sensitiveValues ...string) {
+	if details == nil {
+		return
+	}
+	for _, sensitiveValue := range sensitiveValues {
+		details.RequestBody = redactSensitiveValue(details.RequestBody, sensitiveValue)
+	}
+	details.RawRequest = nil
+}
+
+func totpVariableCreateSecret(details *TotpVariableV2Input) string {
+	if details == nil {
+		return ""
+	}
+
+	return details.Totp.Secret
+}

--- a/syntheticsclientv2/delete_totpvariablev2.go
+++ b/syntheticsclientv2/delete_totpvariablev2.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+func (c Client) DeleteTotpVariableV2(id int) (int, error) {
+	requestDetails, err := c.makePublicAPICall("DELETE", fmt.Sprintf("/totps/%d", id), bytes.NewBufferString("{}"), nil)
+	if err != nil {
+		return 1, err
+	}
+	var status = requestDetails.StatusCode
+
+	if status >= 300 || status < 200 {
+		errorMsg := fmt.Sprintf("error: Response code %v. Expecting 2XX.", strconv.Itoa(status))
+		return status, errors.New(errorMsg)
+	}
+
+	return status, err
+}

--- a/syntheticsclientv2/get_totpvariablev2.go
+++ b/syntheticsclientv2/get_totpvariablev2.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func parseGetTotpVariableV2Response(response string) (*TotpVariableV2Response, error) {
+	var totpVariableV2 TotpVariableV2Response
+	err := json.Unmarshal([]byte(response), &totpVariableV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &totpVariableV2, err
+}
+
+func (c Client) GetTotpVariableV2(id int) (*TotpVariableV2Response, *RequestDetails, error) {
+	details, err := c.makePublicAPICall("GET", fmt.Sprintf("/totps/%d", id), bytes.NewBufferString("{}"), nil)
+	scrubTotpVariableRequestDetails(details)
+	if err != nil {
+		return nil, details, err
+	}
+
+	totpVariableV2, err := parseGetTotpVariableV2Response(details.ResponseBody)
+	if err != nil {
+		return totpVariableV2, details, err
+	}
+
+	return totpVariableV2, details, nil
+}
+
+func parseGetTotpVariablesV2Response(response string) (*TotpVariablesV2Response, error) {
+	var totpVariablesV2 TotpVariablesV2Response
+	err := json.Unmarshal([]byte(response), &totpVariablesV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &totpVariablesV2, err
+}
+
+func (c Client) GetTotpVariablesV2() (*TotpVariablesV2Response, *RequestDetails, error) {
+	details, err := c.makePublicAPICall("GET", "/totps", bytes.NewBufferString("{}"), nil)
+	scrubTotpVariableRequestDetails(details)
+	if err != nil {
+		return nil, details, err
+	}
+
+	totpVariablesV2, err := parseGetTotpVariablesV2Response(details.ResponseBody)
+	if err != nil {
+		return totpVariablesV2, details, err
+	}
+
+	return totpVariablesV2, details, nil
+}

--- a/syntheticsclientv2/totpvariablev2_test.go
+++ b/syntheticsclientv2/totpvariablev2_test.go
@@ -1,0 +1,382 @@
+//go:build unit_tests
+// +build unit_tests
+
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+var (
+	createTotpVariableV2Body         = `{"totp":{"description":"TOTP for terraform","digits":6,"hmacDigest":"SHA1","interval":30,"name":"terraform-totp","secret":"create-totp-secret"}}`
+	createTotpVariableV2ResponseBody = `{"totp":{"id":101,"name":"terraform-totp","description":"TOTP for terraform","secret":"<REDACTED>","digits":6,"interval":30,"hmacDigest":"SHA1","createdAt":"2026-06-21T10:15:30.001Z","createdBy":"creator","updatedAt":"2026-06-21T10:16:30.001Z","updatedBy":"updater"}}`
+	inputTotpVariableV2Data          = TotpVariableV2Input{}
+	outputTotpVariableV2Data         = verifyTotpVariableV2Input(createTotpVariableV2ResponseBody)
+
+	getTotpVariableV2Body  = `{"totp":{"id":102,"name":"login-totp","description":"Login MFA","secret":"<REDACTED>","digits":8,"interval":60,"hmacDigest":"SHA256","createdAt":"2026-06-20T08:15:30.001Z","createdBy":"creator-id","updatedAt":"2026-06-21T09:16:30.001Z","updatedBy":"updater-id"}}`
+	inputGetTotpVariableV2 = verifyTotpVariableV2Input(getTotpVariableV2Body)
+
+	getTotpVariablesV2Body  = `{"totps":[{"id":201,"name":"first-totp","description":"First MFA","secret":"<REDACTED>","digits":6,"interval":30,"hmacDigest":"SHA1","createdAt":"2026-06-20T08:15:30.001Z","createdBy":"creator-one","updatedAt":"2026-06-21T09:16:30.001Z","updatedBy":"updater-one"},{"id":202,"name":"second-totp","description":"Second MFA","secret":"<REDACTED>","digits":8,"interval":60,"hmacDigest":"SHA512","createdAt":"2026-06-20T10:15:30.001Z","createdBy":"creator-two","updatedAt":"2026-06-21T11:16:30.001Z","updatedBy":"updater-two"}]}`
+	inputGetTotpVariablesV2 = verifyTotpVariablesV2Input(getTotpVariablesV2Body)
+
+	updateTotpVariableV2ResponseBody = `{"totp":{"id":103,"name":"updated-totp","description":"Updated TOTP","secret":"<REDACTED>","digits":8,"interval":45,"hmacDigest":"SHA512","createdAt":"2026-06-20T08:15:30.001Z","createdBy":"creator-id","updatedAt":"2026-06-21T09:16:30.001Z","updatedBy":"updater-id"}}`
+	outputUpdateTotpVariableV2Data   = verifyTotpVariableV2Input(updateTotpVariableV2ResponseBody)
+)
+
+func TestCreateTotpVariableV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	err := json.Unmarshal([]byte(createTotpVariableV2Body), &inputTotpVariableV2Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testMux.HandleFunc("/totps", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		_, requestTotpFields := readTotpRequestFields(t, r)
+		assertTotpRequestFields(t, requestTotpFields, map[string]string{
+			"description": `"TOTP for terraform"`,
+			"digits":      `6`,
+			"hmacDigest":  `"SHA1"`,
+			"interval":    `30`,
+			"name":        `"terraform-totp"`,
+			"secret":      `"create-totp-secret"`,
+		})
+		assertTotpResponseOnlyFieldsAbsent(t, requestTotpFields)
+
+		_, err := w.Write([]byte(createTotpVariableV2ResponseBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	resp, details, err := testClient.CreateTotpVariableV2(&inputTotpVariableV2Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(resp.Totp, outputTotpVariableV2Data.Totp) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Totp, outputTotpVariableV2Data.Totp)
+	}
+	assertDoesNotContain(t, details.RequestBody, "create-totp-secret")
+	assertContains(t, details.RequestBody, `"secret":"[REDACTED]"`, `"hmacDigest":"SHA1"`)
+	assertRawRequestDoesNotExposeSensitiveDetails(t, details, "apiKey", "create-totp-secret")
+}
+
+func TestGetTotpVariableV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/totps/102", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		_, err := w.Write([]byte(getTotpVariableV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	resp, _, err := testClient.GetTotpVariableV2(102)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(resp.Totp, inputGetTotpVariableV2.Totp) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Totp, inputGetTotpVariableV2.Totp)
+	}
+	if resp.Totp.Secret != "<REDACTED>" {
+		t.Errorf("returned secret \n\n%#v want \n\n%#v", resp.Totp.Secret, "<REDACTED>")
+	}
+}
+
+func TestGetTotpVariablesV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/totps", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		_, err := w.Write([]byte(getTotpVariablesV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	resp, _, err := testClient.GetTotpVariablesV2()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(resp.Totps, inputGetTotpVariablesV2.Totps) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Totps, inputGetTotpVariablesV2.Totps)
+	}
+}
+
+func TestUpdateTotpVariableV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	description := "Updated TOTP"
+	digits := 8
+	hmacDigest := "SHA512"
+	interval := 45
+	secret := "update-totp-secret"
+	updateInput := TotpVariableV2UpdateInput{
+		Totp: TotpVariableUpdateInput{
+			Description: &description,
+			Digits:      &digits,
+			HmacDigest:  &hmacDigest,
+			Interval:    &interval,
+			Secret:      &secret,
+		},
+	}
+
+	testMux.HandleFunc("/totps/103", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		_, requestTotpFields := readTotpRequestFields(t, r)
+		assertTotpRequestFields(t, requestTotpFields, map[string]string{
+			"description": `"Updated TOTP"`,
+			"digits":      `8`,
+			"hmacDigest":  `"SHA512"`,
+			"interval":    `45`,
+			"secret":      `"update-totp-secret"`,
+		})
+		assertTotpUpdateForbiddenFieldsAbsent(t, requestTotpFields)
+
+		_, err := w.Write([]byte(updateTotpVariableV2ResponseBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	resp, details, err := testClient.UpdateTotpVariableV2(103, &updateInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(resp.Totp, outputUpdateTotpVariableV2Data.Totp) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Totp, outputUpdateTotpVariableV2Data.Totp)
+	}
+	assertDoesNotContain(t, details.RequestBody, "update-totp-secret")
+	assertContains(t, details.RequestBody, `"secret":"[REDACTED]"`, `"hmacDigest":"SHA512"`)
+	assertRawRequestDoesNotExposeSensitiveDetails(t, details, "apiKey", "update-totp-secret")
+}
+
+func TestUpdateTotpVariableV2OmitsNilSecret(t *testing.T) {
+	setup()
+	defer teardown()
+
+	description := ""
+	digits := 8
+	hmacDigest := "SHA256"
+	interval := 60
+	updateInput := TotpVariableV2UpdateInput{
+		Totp: TotpVariableUpdateInput{
+			Description: &description,
+			Digits:      &digits,
+			HmacDigest:  &hmacDigest,
+			Interval:    &interval,
+		},
+	}
+
+	testMux.HandleFunc("/totps/104", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		_, requestTotpFields := readTotpRequestFields(t, r)
+		assertTotpRequestFields(t, requestTotpFields, map[string]string{
+			"description": `""`,
+			"digits":      `8`,
+			"hmacDigest":  `"SHA256"`,
+			"interval":    `60`,
+		})
+		assertTotpUpdateForbiddenFieldsAbsent(t, requestTotpFields)
+		if _, ok := requestTotpFields["secret"]; ok {
+			t.Fatal("request body should omit totp.secret when Secret is nil")
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	resp, _, err := testClient.UpdateTotpVariableV2(104, &updateInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response for blank successful update body")
+	}
+}
+
+func TestDeleteTotpVariableV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/totps/105", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	resp, err := testClient.DeleteTotpVariableV2(105)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != http.StatusNoContent {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, http.StatusNoContent)
+	}
+}
+
+func verifyTotpVariableV2Input(stringInput string) *TotpVariableV2Response {
+	check := &TotpVariableV2Response{}
+	err := json.Unmarshal([]byte(stringInput), check)
+	if err != nil {
+		panic(err)
+	}
+	return check
+}
+
+func verifyTotpVariablesV2Input(stringInput string) *TotpVariablesV2Response {
+	check := &TotpVariablesV2Response{}
+	err := json.Unmarshal([]byte(stringInput), check)
+	if err != nil {
+		panic(err)
+	}
+	return check
+}
+
+func readTotpRequestFields(t *testing.T, r *http.Request) ([]byte, map[string]json.RawMessage) {
+	t.Helper()
+
+	requestBody, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var requestEnvelope map[string]json.RawMessage
+	err = json.Unmarshal(requestBody, &requestEnvelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(requestEnvelope) != 1 {
+		t.Fatalf("request body envelope keys \n\n%#v want only totp", requestEnvelope)
+	}
+	rawTotp, ok := requestEnvelope["totp"]
+	if !ok {
+		t.Fatal("request body missing totp envelope")
+	}
+
+	var requestTotpFields map[string]json.RawMessage
+	err = json.Unmarshal(rawTotp, &requestTotpFields)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := requestTotpFields["hmac_digest"]; ok {
+		t.Fatal("request body should use hmacDigest, not hmac_digest")
+	}
+	if _, ok := requestTotpFields["hmacdigest"]; ok {
+		t.Fatal("request body should use hmacDigest, not hmacdigest")
+	}
+
+	return requestBody, requestTotpFields
+}
+
+func assertTotpRequestFields(t *testing.T, requestTotpFields map[string]json.RawMessage, expectedFields map[string]string) {
+	t.Helper()
+
+	if len(requestTotpFields) != len(expectedFields) {
+		t.Errorf("request body totp field count %d want %d", len(requestTotpFields), len(expectedFields))
+	}
+	for field, expected := range expectedFields {
+		rawValue, ok := requestTotpFields[field]
+		if !ok {
+			t.Errorf("request body missing totp.%s", field)
+			continue
+		}
+		if string(rawValue) != expected {
+			t.Errorf("request body totp.%s %s want %s", field, rawValue, expected)
+		}
+	}
+}
+
+func assertTotpResponseOnlyFieldsAbsent(t *testing.T, requestTotpFields map[string]json.RawMessage) {
+	t.Helper()
+
+	for _, field := range []string{"id", "createdAt", "createdBy", "updatedAt", "updatedBy"} {
+		if _, ok := requestTotpFields[field]; ok {
+			t.Errorf("request body should not include totp.%s", field)
+		}
+	}
+}
+
+func assertTotpUpdateForbiddenFieldsAbsent(t *testing.T, requestTotpFields map[string]json.RawMessage) {
+	t.Helper()
+
+	assertTotpResponseOnlyFieldsAbsent(t, requestTotpFields)
+	if _, ok := requestTotpFields["name"]; ok {
+		t.Error("request body should not include immutable totp.name")
+	}
+}
+
+func assertRawRequestDoesNotExposeSensitiveDetails(t *testing.T, details *RequestDetails, apiKey string, secrets ...string) {
+	t.Helper()
+
+	if details.RawRequest == nil {
+		return
+	}
+
+	if details.RawRequest.Header.Get("X-SF-TOKEN") == apiKey {
+		t.Errorf("raw request exposes real X-SF-TOKEN header")
+	}
+
+	if details.RawRequest.GetBody == nil {
+		return
+	}
+
+	body, err := details.RawRequest.GetBody()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer body.Close()
+
+	rawBody, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertDoesNotContain(t, string(rawBody), secrets...)
+}
+
+func assertContains(t *testing.T, text string, values ...string) {
+	t.Helper()
+
+	for _, value := range values {
+		if !strings.Contains(text, value) {
+			t.Errorf("expected text to contain %q\ntext:\n%s", value, text)
+		}
+	}
+}
+
+func assertDoesNotContain(t *testing.T, text string, values ...string) {
+	t.Helper()
+
+	for _, value := range values {
+		if strings.Contains(text, value) {
+			t.Errorf("expected text to omit %q\ntext:\n%s", value, text)
+		}
+	}
+}

--- a/syntheticsclientv2/update_totpvariablev2.go
+++ b/syntheticsclientv2/update_totpvariablev2.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func parseUpdateTotpVariableV2Response(response string) (*TotpVariableV2Response, error) {
+	var updateTotpVariableV2 TotpVariableV2Response
+	if response != "" {
+		err := json.Unmarshal([]byte(response), &updateTotpVariableV2)
+		if err != nil {
+			return nil, err
+		}
+		return &updateTotpVariableV2, err
+	}
+	return &updateTotpVariableV2, nil
+}
+
+func (c Client) UpdateTotpVariableV2(id int, TotpVariableV2Details *TotpVariableV2UpdateInput) (*TotpVariableV2Response, *RequestDetails, error) {
+	body, err := json.Marshal(TotpVariableV2Details)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	requestDetails, err := c.makePublicAPICall("PUT", fmt.Sprintf("/totps/%d", id), bytes.NewBuffer(body), nil)
+	scrubTotpVariableRequestDetails(requestDetails, totpVariableUpdateSecret(TotpVariableV2Details))
+	if err != nil {
+		return nil, requestDetails, err
+	}
+
+	updateTotpVariableV2, err := parseUpdateTotpVariableV2Response(requestDetails.ResponseBody)
+	if err != nil {
+		return updateTotpVariableV2, requestDetails, err
+	}
+
+	return updateTotpVariableV2, requestDetails, nil
+}
+
+func totpVariableUpdateSecret(details *TotpVariableV2UpdateInput) string {
+	if details == nil || details.Totp.Secret == nil {
+		return ""
+	}
+
+	return *details.Totp.Secret
+}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves SYN-6665

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* `syntheticsclientv2` did not expose the Synthetics `/totps` API, so Terraform/provider work could not manage TOTP variables through the released client.
* `RequestDetails.RequestBody` could retain sensitive request data, including auth headers and secret request body fields.
* `RequestDetails.RawRequest` retained the original request, which could expose API tokens or request-body secrets.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Adds `syntheticsclientv2` TOTP variable models and CRUD methods for `/totps`.
* Supports create, get, list, update, and delete using the confirmed API roots: `totp` and `totps`.
* Redacts sensitive request details, including auth/cookie headers, JSON `secret`, `password`, and `content` fields, browser header values, and browser cookie values.
* Stops retaining `RawRequest` in `RequestDetails` to avoid exposing original auth headers or secret request bodies.
* Adds unit coverage for the TOTP API contract, update pointer semantics, redaction behavior, and non-over-redaction of benign values.

### Pull request checklist 
- [x] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
<!-- Please paste the results of acceptance tests `make testacc` in the codeblock here. -->

Client-only change; no live acceptance tests were run. Unit tests:

```text
go test ./syntheticsclientv2 -tags=unit_tests -run 'TestSanitizeRequestDumpStoredInRequestDetails|Test(Create|Update)TotpVariableV2|TestMakePublicAPICallStoresRedactedRequestDetailsForTotpVariableCRUD' -count=1
ok

go test ./syntheticsclientv2 -tags=unit_tests -count=1
ok
```

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----
