### PR TITLE
SYN-3601: preserve request redaction

### DIFF
--- a/syntheticsclientv2/synthetics.go
+++ b/syntheticsclientv2/synthetics.go
@@ -145,17 +145,21 @@ func redactCaCertificateContent(requestDump string) string {
 
 	var requestBody interface{}
 	if err := json.Unmarshal([]byte(requestParts[1]), &requestBody); err != nil {
-		return requestDump
+		return replaceRequestDumpBody(requestParts[0])
 	}
 
 	redactContentFields(requestBody)
 
 	redactedRequestBody, err := json.Marshal(requestBody)
 	if err != nil {
-		return requestDump
+		return replaceRequestDumpBody(requestParts[0])
 	}
 
 	return requestParts[0] + headerBodySeparator + string(redactedRequestBody)
+}
+
+func replaceRequestDumpBody(headers string) string {
+	return headers + "\r\n\r\n[REDACTED]"
 }
 
 func redactContentFields(value interface{}) {

--- a/syntheticsclientv2/synthetics.go
+++ b/syntheticsclientv2/synthetics.go
@@ -136,30 +136,39 @@ func sanitizeRequestDump(requestDump string, apiKey string, endpoint string) str
 }
 
 func redactCaCertificateContent(requestDump string) string {
-	const headerBodySeparator = "\r\n\r\n"
-
-	requestParts := strings.SplitN(requestDump, headerBodySeparator, 2)
-	if len(requestParts) != 2 || requestParts[1] == "" {
+	headers, body, separator, ok := splitRequestDump(requestDump)
+	if !ok || body == "" {
 		return requestDump
 	}
 
 	var requestBody interface{}
-	if err := json.Unmarshal([]byte(requestParts[1]), &requestBody); err != nil {
-		return replaceRequestDumpBody(requestParts[0])
+	if err := json.Unmarshal([]byte(body), &requestBody); err != nil {
+		return replaceRequestDumpBody(headers, separator)
 	}
 
 	redactContentFields(requestBody)
 
 	redactedRequestBody, err := json.Marshal(requestBody)
 	if err != nil {
-		return replaceRequestDumpBody(requestParts[0])
+		return replaceRequestDumpBody(headers, separator)
 	}
 
-	return requestParts[0] + headerBodySeparator + string(redactedRequestBody)
+	return headers + separator + string(redactedRequestBody)
 }
 
-func replaceRequestDumpBody(headers string) string {
-	return headers + "\r\n\r\n[REDACTED]"
+func splitRequestDump(requestDump string) (string, string, string, bool) {
+	for _, separator := range []string{"\r\n\r\n", "\n\n"} {
+		requestParts := strings.SplitN(requestDump, separator, 2)
+		if len(requestParts) == 2 {
+			return requestParts[0], requestParts[1], separator, true
+		}
+	}
+
+	return "", "", "", false
+}
+
+func replaceRequestDumpBody(headers string, separator string) string {
+	return headers + separator + "[REDACTED]"
 }
 
 func redactContentFields(value interface{}) {

--- a/syntheticsclientv2/synthetics.go
+++ b/syntheticsclientv2/synthetics.go
@@ -85,7 +85,7 @@ func (c Client) makePublicAPICall(method string, endpoint string, requestBody io
 	if err != nil {
 		return &details, err
 	}
-	details.RequestBody = redactSensitiveValue(string(requestDump), c.apiKey)
+	details.RequestBody = sanitizeRequestDump(string(requestDump), c.apiKey, endpoint)
 
 	// Make the request
 	resp, err := c.httpClient.Do(req)
@@ -124,6 +124,55 @@ func redactSensitiveValue(value string, sensitiveValue string) string {
 	}
 
 	return strings.ReplaceAll(value, sensitiveValue, "[REDACTED]")
+}
+
+func sanitizeRequestDump(requestDump string, apiKey string, endpoint string) string {
+	sanitizedRequestDump := redactSensitiveValue(requestDump, apiKey)
+	if !strings.Contains(endpoint, "/cacerts") {
+		return sanitizedRequestDump
+	}
+
+	return redactCaCertificateContent(sanitizedRequestDump)
+}
+
+func redactCaCertificateContent(requestDump string) string {
+	const headerBodySeparator = "\r\n\r\n"
+
+	requestParts := strings.SplitN(requestDump, headerBodySeparator, 2)
+	if len(requestParts) != 2 || requestParts[1] == "" {
+		return requestDump
+	}
+
+	var requestBody interface{}
+	if err := json.Unmarshal([]byte(requestParts[1]), &requestBody); err != nil {
+		return requestDump
+	}
+
+	redactContentFields(requestBody)
+
+	redactedRequestBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return requestDump
+	}
+
+	return requestParts[0] + headerBodySeparator + string(redactedRequestBody)
+}
+
+func redactContentFields(value interface{}) {
+	switch typedValue := value.(type) {
+	case map[string]interface{}:
+		for key, nestedValue := range typedValue {
+			if strings.EqualFold(key, "content") {
+				typedValue[key] = "[REDACTED]"
+				continue
+			}
+			redactContentFields(nestedValue)
+		}
+	case []interface{}:
+		for _, nestedValue := range typedValue {
+			redactContentFields(nestedValue)
+		}
+	}
 }
 
 func NewClientArgs(timeout int, baseUrl string) ClientArgs {

--- a/syntheticsclientv2/synthetics_test.go
+++ b/syntheticsclientv2/synthetics_test.go
@@ -188,6 +188,70 @@ func TestMakePublicAPICallRedactsCaCertificateContentFromRequestDetails(t *testi
 	}
 }
 
+func TestMakePublicAPICallRedactsMalformedCaCertificateRequestBody(t *testing.T) {
+	requestDump := "POST /cacerts HTTP/1.1\r\nHost: example.com\r\nX-Sf-Token: secret-api-key\r\n\r\n{\"cacert\":{\"content\":\"private-ca-material\""
+
+	got := sanitizeRequestDump(requestDump, "secret-api-key", "/cacerts")
+
+	if strings.Contains(got, "secret-api-key") {
+		t.Fatalf("expected request details to redact API key, but found it in: %s", got)
+	}
+	if strings.Contains(got, "private-ca-material") {
+		t.Fatalf("expected request details to redact malformed CA certificate body, but found it in: %s", got)
+	}
+	if !strings.Contains(got, "Host: example.com") {
+		t.Fatalf("expected request details to preserve headers, but saw: %s", got)
+	}
+	if !strings.HasSuffix(got, "\r\n\r\n[REDACTED]") {
+		t.Fatalf("expected request details to replace malformed body with redaction marker, but saw: %s", got)
+	}
+}
+
+func TestCreateCaCertificateV2RedactsRequestDetails(t *testing.T) {
+	testMux = http.NewServeMux()
+	testServer = httptest.NewServer(testMux)
+	defer testServer.Close()
+
+	testMux.HandleFunc("/cacerts", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"cacert":{"id":1,"name":"test-ca","description":"private test CA","content":"<REDACTED>","fileExtension":"pem","filename":"ca.pem"}}`))
+	})
+
+	apiKey := "secret-api-key"
+	caCertificateContent := "private-ca-material"
+	testConfigurableClient := NewConfigurableClient(apiKey, "realm", ClientArgs{
+		publicBaseUrl: testServer.URL,
+	})
+	input := CaCertificateV2Input{}
+	input.CaCert.Name = "test-ca"
+	input.CaCert.Description = "private test CA"
+	input.CaCert.Content = caCertificateContent
+	input.CaCert.FileExtension = "pem"
+	input.CaCert.Filename = "ca.pem"
+
+	_, details, err := testConfigurableClient.CreateCaCertificateV2(&input)
+	if err != nil {
+		t.Fatalf("expected no error, but saw: %s", err.Error())
+	}
+	if details == nil {
+		t.Fatal("expected request details")
+	}
+
+	if strings.Contains(details.RequestBody, apiKey) {
+		t.Fatalf("expected request details to redact API key, but found it in: %s", details.RequestBody)
+	}
+	if strings.Contains(details.RequestBody, caCertificateContent) {
+		t.Fatalf("expected request details to redact CA certificate content, but found it in: %s", details.RequestBody)
+	}
+	if !strings.Contains(details.RequestBody, "X-Sf-Token: [REDACTED]") {
+		t.Fatalf("expected request details to contain redacted API token header, but saw: %s", details.RequestBody)
+	}
+	if !strings.Contains(details.RequestBody, `"content":"[REDACTED]"`) {
+		t.Fatalf("expected request details to contain redacted CA certificate content field, but saw: %s", details.RequestBody)
+	}
+}
+
 func TestRedactSensitiveValueIgnoresEmptyValue(t *testing.T) {
 	requestDump := "GET /tests HTTP/1.1\r\nX-Sf-Token: \r\n\r\n{}"
 

--- a/syntheticsclientv2/synthetics_test.go
+++ b/syntheticsclientv2/synthetics_test.go
@@ -207,6 +207,25 @@ func TestMakePublicAPICallRedactsMalformedCaCertificateRequestBody(t *testing.T)
 	}
 }
 
+func TestMakePublicAPICallRedactsMalformedCaCertificateRequestBodyWithLFSeparator(t *testing.T) {
+	requestDump := "POST /cacerts HTTP/1.1\nHost: example.com\nX-Sf-Token: secret-api-key\n\n{\"cacert\":{\"content\":\"private-ca-material\""
+
+	got := sanitizeRequestDump(requestDump, "secret-api-key", "/cacerts")
+
+	if strings.Contains(got, "secret-api-key") {
+		t.Fatalf("expected request details to redact API key, but found it in: %s", got)
+	}
+	if strings.Contains(got, "private-ca-material") {
+		t.Fatalf("expected request details to redact malformed CA certificate body, but found it in: %s", got)
+	}
+	if !strings.Contains(got, "Host: example.com") {
+		t.Fatalf("expected request details to preserve headers, but saw: %s", got)
+	}
+	if !strings.HasSuffix(got, "\n\n[REDACTED]") {
+		t.Fatalf("expected request details to preserve LF separator before redaction marker, but saw: %s", got)
+	}
+}
+
 func TestCreateCaCertificateV2RedactsRequestDetails(t *testing.T) {
 	testMux = http.NewServeMux()
 	testServer = httptest.NewServer(testMux)

--- a/syntheticsclientv2/synthetics_test.go
+++ b/syntheticsclientv2/synthetics_test.go
@@ -152,6 +152,42 @@ func TestMakePublicAPICallRedactsAPIKeyFromRequestDetails(t *testing.T) {
 	}
 }
 
+func TestMakePublicAPICallRedactsCaCertificateContentFromRequestDetails(t *testing.T) {
+	testMux = http.NewServeMux()
+	testServer = httptest.NewServer(testMux)
+	defer testServer.Close()
+
+	testMux.HandleFunc("/cacerts", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`))
+	})
+
+	apiKey := "secret-api-key"
+	caCertificateContent := "private-ca-material"
+	testConfigurableClient := NewConfigurableClient(apiKey, "realm", ClientArgs{
+		publicBaseUrl: testServer.URL,
+	})
+
+	requestBody := `{"cacert":{"name":"test-ca","content":"` + caCertificateContent + `","metadata":{"Content":"` + caCertificateContent + `"}}}`
+	details, err := testConfigurableClient.makePublicAPICall("POST", "/cacerts", bytes.NewBufferString(requestBody), nil)
+	if err != nil {
+		t.Fatalf("expected no error, but saw: %s", err.Error())
+	}
+
+	if strings.Contains(details.RequestBody, apiKey) {
+		t.Fatalf("expected request details to redact API key, but found it in: %s", details.RequestBody)
+	}
+	if strings.Contains(details.RequestBody, caCertificateContent) {
+		t.Fatalf("expected request details to redact CA certificate content, but found it in: %s", details.RequestBody)
+	}
+	if !strings.Contains(details.RequestBody, `"content":"[REDACTED]"`) {
+		t.Fatalf("expected request details to preserve redacted content field, but saw: %s", details.RequestBody)
+	}
+	if !strings.Contains(details.RequestBody, `"Content":"[REDACTED]"`) {
+		t.Fatalf("expected request details to redact content fields case-insensitively, but saw: %s", details.RequestBody)
+	}
+}
+
 func TestRedactSensitiveValueIgnoresEmptyValue(t *testing.T) {
 	requestDump := "GET /tests HTTP/1.1\r\nX-Sf-Token: \r\n\r\n{}"
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves #SYN-3601

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* `RequestDetails.RequestBody` redacted the API token, but `/cacerts` request bodies could still expose CA certificate `content`.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Preserves API token redaction in `RequestDetails.RequestBody`.
* Redacts recursive, case-insensitive `content` fields for `/cacerts` request bodies.
* Preserves request diagnostic structure for valid JSON bodies.
* Fails closed for malformed `/cacerts` request bodies by preserving headers and replacing the body with `[REDACTED]`.
* Supports both CRLF and LF-only request dump separators.
* Adds regression coverage for direct sanitizer behavior and `CreateCaCertificateV2` returned request details.

### Pull request checklist 
- [x] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
<!-- Please paste the results of acceptance tests `make testacc` in the codeblock here. -->

```text
go test ./syntheticsclientv2 -tags=unit_tests -run 'Test.*Redact|Test.*RequestDetails|Test.*CaCertificate' -count=1
go test ./syntheticsclientv2 -tags=unit_tests -run 'Test(Create|Update|Get)HttpCheckV2WithNullablePort' -count=1
go test ./syntheticsclientv2 -tags=unit_tests -count=1
```

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----
