### PR TITLE
SYN-6770: preserve request redaction

### DIFF
--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -829,16 +829,8 @@ type BrowserCheckV2Input struct {
 
 func (b BrowserCheckV2Input) MarshalJSON() ([]byte, error) {
 	type advancedSettingsJSON struct {
-		Authentication            *Authentication  `json:"authentication"`
-		Cookiesv2                 []Cookiesv2      `json:"cookies"`
-		BrowserHeaders            []BrowserHeaders `json:"headers"`
-		HostOverrides             []HostOverrides  `json:"hostOverrides"`
-		UserAgent                 *string          `json:"userAgent"`
-		CollectInteractiveMetrics bool             `json:"collectInteractiveMetrics"`
-		Verifycertificates        bool             `json:"verifyCertificates"`
-		ChromeFlags               []ChromeFlag     `json:"chromeFlags"`
-		ExcludedFiles             []ExcludedFile   `json:"excludedFiles"`
-		CertificateIDs            *[]int           `json:"certificateIds,omitempty"`
+		Advancedsettings
+		CertificateIDs *[]int `json:"certificateIds,omitempty"`
 	}
 
 	type browserCheckV2InputTestJSON struct {
@@ -856,17 +848,7 @@ func (b BrowserCheckV2Input) MarshalJSON() ([]byte, error) {
 		Automaticretries   int                  `json:"automaticRetries"`
 	}
 
-	advancedSettings := advancedSettingsJSON{
-		Authentication:            b.Test.Authentication,
-		Cookiesv2:                 b.Test.Cookiesv2,
-		BrowserHeaders:            b.Test.BrowserHeaders,
-		HostOverrides:             b.Test.HostOverrides,
-		UserAgent:                 b.Test.UserAgent,
-		CollectInteractiveMetrics: b.Test.CollectInteractiveMetrics,
-		Verifycertificates:        b.Test.Verifycertificates,
-		ChromeFlags:               b.Test.ChromeFlags,
-		ExcludedFiles:             b.Test.ExcludedFiles,
-	}
+	advancedSettings := advancedSettingsJSON{Advancedsettings: b.Test.Advancedsettings}
 	if b.Test.CertificateIDs != nil {
 		advancedSettings.CertificateIDs = &b.Test.CertificateIDs
 	}

--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -109,38 +109,6 @@ type Advancedsettings struct {
 	CertificateIDs            []int            `json:"certificateIds,omitempty"`
 }
 
-func (a Advancedsettings) MarshalJSON() ([]byte, error) {
-	type advancedsettingsJSON struct {
-		Authentication            *Authentication  `json:"authentication"`
-		Cookiesv2                 []Cookiesv2      `json:"cookies"`
-		BrowserHeaders            []BrowserHeaders `json:"headers"`
-		HostOverrides             []HostOverrides  `json:"hostOverrides"`
-		UserAgent                 *string          `json:"userAgent"`
-		CollectInteractiveMetrics bool             `json:"collectInteractiveMetrics"`
-		Verifycertificates        bool             `json:"verifyCertificates"`
-		ChromeFlags               []ChromeFlag     `json:"chromeFlags"`
-		ExcludedFiles             []ExcludedFile   `json:"excludedFiles"`
-		CertificateIDs            *[]int           `json:"certificateIds,omitempty"`
-	}
-
-	advancedsettings := advancedsettingsJSON{
-		Authentication:            a.Authentication,
-		Cookiesv2:                 a.Cookiesv2,
-		BrowserHeaders:            a.BrowserHeaders,
-		HostOverrides:             a.HostOverrides,
-		UserAgent:                 a.UserAgent,
-		CollectInteractiveMetrics: a.CollectInteractiveMetrics,
-		Verifycertificates:        a.Verifycertificates,
-		ChromeFlags:               a.ChromeFlags,
-		ExcludedFiles:             a.ExcludedFiles,
-	}
-	if a.CertificateIDs != nil {
-		advancedsettings.CertificateIDs = &a.CertificateIDs
-	}
-
-	return json.Marshal(advancedsettings)
-}
-
 type ChromeFlag struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
@@ -857,6 +825,70 @@ type BrowserCheckV2Input struct {
 		Customproperties   []CustomProperties `json:"customProperties"`
 		Automaticretries   int                `json:"automaticRetries"`
 	} `json:"test"`
+}
+
+func (b BrowserCheckV2Input) MarshalJSON() ([]byte, error) {
+	type advancedSettingsJSON struct {
+		Authentication            *Authentication  `json:"authentication"`
+		Cookiesv2                 []Cookiesv2      `json:"cookies"`
+		BrowserHeaders            []BrowserHeaders `json:"headers"`
+		HostOverrides             []HostOverrides  `json:"hostOverrides"`
+		UserAgent                 *string          `json:"userAgent"`
+		CollectInteractiveMetrics bool             `json:"collectInteractiveMetrics"`
+		Verifycertificates        bool             `json:"verifyCertificates"`
+		ChromeFlags               []ChromeFlag     `json:"chromeFlags"`
+		ExcludedFiles             []ExcludedFile   `json:"excludedFiles"`
+		CertificateIDs            *[]int           `json:"certificateIds,omitempty"`
+	}
+
+	type browserCheckV2InputTestJSON struct {
+		Name               string               `json:"name"`
+		Transactions       []Transactions       `json:"transactions"`
+		Urlprotocol        string               `json:"urlProtocol"`
+		Starturl           string               `json:"startUrl"`
+		LocationIds        []string             `json:"locationIds"`
+		DeviceID           int                  `json:"deviceId"`
+		Frequency          int                  `json:"frequency"`
+		Schedulingstrategy string               `json:"schedulingStrategy"`
+		Active             bool                 `json:"active"`
+		Advancedsettings   advancedSettingsJSON `json:"advancedSettings,omitempty"`
+		Customproperties   []CustomProperties   `json:"customProperties"`
+		Automaticretries   int                  `json:"automaticRetries"`
+	}
+
+	advancedSettings := advancedSettingsJSON{
+		Authentication:            b.Test.Authentication,
+		Cookiesv2:                 b.Test.Cookiesv2,
+		BrowserHeaders:            b.Test.BrowserHeaders,
+		HostOverrides:             b.Test.HostOverrides,
+		UserAgent:                 b.Test.UserAgent,
+		CollectInteractiveMetrics: b.Test.CollectInteractiveMetrics,
+		Verifycertificates:        b.Test.Verifycertificates,
+		ChromeFlags:               b.Test.ChromeFlags,
+		ExcludedFiles:             b.Test.ExcludedFiles,
+	}
+	if b.Test.CertificateIDs != nil {
+		advancedSettings.CertificateIDs = &b.Test.CertificateIDs
+	}
+
+	return json.Marshal(struct {
+		Test browserCheckV2InputTestJSON `json:"test"`
+	}{
+		Test: browserCheckV2InputTestJSON{
+			Name:               b.Test.Name,
+			Transactions:       b.Test.Transactions,
+			Urlprotocol:        b.Test.Urlprotocol,
+			Starturl:           b.Test.Starturl,
+			LocationIds:        b.Test.LocationIds,
+			DeviceID:           b.Test.DeviceID,
+			Frequency:          b.Test.Frequency,
+			Schedulingstrategy: b.Test.Schedulingstrategy,
+			Active:             b.Test.Active,
+			Advancedsettings:   advancedSettings,
+			Customproperties:   b.Test.Customproperties,
+			Automaticretries:   b.Test.Automaticretries,
+		},
+	})
 }
 
 type BrowserCheckV2Response struct {

--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -109,6 +109,38 @@ type Advancedsettings struct {
 	CertificateIDs            []int            `json:"certificateIds,omitempty"`
 }
 
+func (a Advancedsettings) MarshalJSON() ([]byte, error) {
+	type advancedsettingsJSON struct {
+		Authentication            *Authentication  `json:"authentication"`
+		Cookiesv2                 []Cookiesv2      `json:"cookies"`
+		BrowserHeaders            []BrowserHeaders `json:"headers"`
+		HostOverrides             []HostOverrides  `json:"hostOverrides"`
+		UserAgent                 *string          `json:"userAgent"`
+		CollectInteractiveMetrics bool             `json:"collectInteractiveMetrics"`
+		Verifycertificates        bool             `json:"verifyCertificates"`
+		ChromeFlags               []ChromeFlag     `json:"chromeFlags"`
+		ExcludedFiles             []ExcludedFile   `json:"excludedFiles"`
+		CertificateIDs            *[]int           `json:"certificateIds,omitempty"`
+	}
+
+	advancedsettings := advancedsettingsJSON{
+		Authentication:            a.Authentication,
+		Cookiesv2:                 a.Cookiesv2,
+		BrowserHeaders:            a.BrowserHeaders,
+		HostOverrides:             a.HostOverrides,
+		UserAgent:                 a.UserAgent,
+		CollectInteractiveMetrics: a.CollectInteractiveMetrics,
+		Verifycertificates:        a.Verifycertificates,
+		ChromeFlags:               a.ChromeFlags,
+		ExcludedFiles:             a.ExcludedFiles,
+	}
+	if a.CertificateIDs != nil {
+		advancedsettings.CertificateIDs = &a.CertificateIDs
+	}
+
+	return json.Marshal(advancedsettings)
+}
+
 type ChromeFlag struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`

--- a/syntheticsclientv2/create_apicheckv2_test.go
+++ b/syntheticsclientv2/create_apicheckv2_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	createApiV2Body = `{"test":{"automaticRetries": 1,"customProperties": [{"key": "Test_Key", "value": "Test Custom Properties"}], "active":true,"deviceId":1,"frequency":5,"location_ids":["aws-us-east-1"],"name":"boop-test","scheduling_strategy":"round_robin","requests":[{"configuration":{"name":"Get-Test","requestMethod":"GET","url":"https://api.us1.signalfx.com/v2/synthetics/v2/tests/api/489","certificateId":123,"headers":{"X-SF-TOKEN":"jinglebellsbatmanshells", "beep":"boop"},"body":null},"setup":[{"name":"Extract from response body","type":"extract_json","source":"{{response.body}}","extractor":"$.requests","variable":"custom-varz"}],"validations":[{"name":"Assert response code equals 200","type":"assert_numeric","actual":"{{response.code}}","expected":"200","comparator":"equals"}]}]}}`
+	createApiV2Body = `{"test":{"automaticRetries": 1,"customProperties": [{"key": "Test_Key", "value": "Test Custom Properties"}], "active":true,"deviceId":1,"frequency":5,"location_ids":["aws-us-east-1"],"name":"boop-test","scheduling_strategy":"round_robin","requests":[{"configuration":{"name":"Get-Test","requestMethod":"GET","url":"https://api.us1.signalfx.com/v2/synthetics/v2/tests/api/489","certificateId":123,"headers":{"X-SF-TOKEN":"jinglebellsbatmanshells", "beep":"plain-header-secret"},"body":null},"setup":[{"name":"Extract from response body","type":"extract_json","source":"{{response.body}}","extractor":"$.requests","variable":"custom-varz"}],"validations":[{"name":"Assert response code equals 200","type":"assert_numeric","actual":"{{response.code}}","expected":"200","comparator":"equals"}]}]}}`
 	inputData       = ApiCheckV2Input{}
 )
 
@@ -58,10 +58,23 @@ func TestCreateApiCheckV2(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp, _, err := testClient.CreateApiCheckV2(&inputData)
+	resp, details, err := testClient.CreateApiCheckV2(&inputData)
 
 	if err != nil {
 		t.Fatal(err)
+	}
+	if details == nil {
+		t.Fatal("expected request details")
+	}
+	for _, secret := range []string{"jinglebellsbatmanshells", "plain-header-secret"} {
+		if strings.Contains(details.RequestBody, secret) {
+			t.Fatalf("expected request details to redact API check header value %q, but saw: %s", secret, details.RequestBody)
+		}
+	}
+	for _, redacted := range []string{`"X-SF-TOKEN":"[REDACTED]"`, `"beep":"[REDACTED]"`} {
+		if !strings.Contains(details.RequestBody, redacted) {
+			t.Fatalf("expected request details to contain redacted header %q, but saw: %s", redacted, details.RequestBody)
+		}
 	}
 
 	if !reflect.DeepEqual(resp.Test.Name, inputData.Test.Name) {

--- a/syntheticsclientv2/create_browsercheckv2_test.go
+++ b/syntheticsclientv2/create_browsercheckv2_test.go
@@ -41,11 +41,15 @@ func TestCreateBrowserCheckV2(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !strings.Contains(string(requestBody), `"certificateIds":[123]`) {
-			t.Fatalf("request body missing certificateIds: %s", requestBody)
+		requestBodyString := string(requestBody)
+		testPayload := browserCheckV2RequestTestPayload(t, requestBodyString)
+		if got := testPayload["name"]; got != "browser-beep-test" {
+			t.Fatalf("expected request body to preserve browser test name, but saw %#v in body: %s", got, requestBodyString)
 		}
-		if strings.Contains(string(requestBody), "certificate_ids") {
-			t.Fatalf("request body contains internal certificate_ids field: %s", requestBody)
+		advancedSettings := browserCheckV2RequestAdvancedSettingsPayload(t, requestBodyString)
+		assertBrowserCheckV2RequestCertificateIDs(t, advancedSettings, []int{123})
+		if strings.Contains(requestBodyString, "certificate_ids") {
+			t.Fatalf("request body contains internal certificate_ids field: %s", requestBodyString)
 		}
 		_, err = w.Write([]byte(createBrowserCheckV2Body))
 		if err != nil {

--- a/syntheticsclientv2/synthetics.go
+++ b/syntheticsclientv2/synthetics.go
@@ -68,6 +68,16 @@ var sensitiveJSONFieldNames = map[string]struct{}{
 	"value":    {},
 }
 
+var sensitiveHeaderNames = map[string]struct{}{
+	"authorization":       {},
+	"proxy-authorization": {},
+	"cookie":              {},
+	"set-cookie":          {},
+	"x-sf-token":          {},
+	"x-api-key":           {},
+	"api-key":             {},
+}
+
 func (c Client) makePublicAPICall(method string, endpoint string, requestBody io.Reader, queryParams map[string]string) (*RequestDetails, error) {
 	details := RequestDetails{}
 	// Create the request
@@ -183,6 +193,14 @@ func redactSensitiveJSONFields(value interface{}) {
 				typedValue[key] = "[REDACTED]"
 				continue
 			}
+			if isSensitiveHeaderName(key) {
+				typedValue[key] = "[REDACTED]"
+				continue
+			}
+			if strings.EqualFold(key, "headers") {
+				redactHeaderValues(nestedValue)
+				continue
+			}
 			redactSensitiveJSONFields(nestedValue)
 		}
 	case []interface{}:
@@ -190,6 +208,28 @@ func redactSensitiveJSONFields(value interface{}) {
 			redactSensitiveJSONFields(nestedValue)
 		}
 	}
+}
+
+func redactHeaderValues(value interface{}) {
+	switch typedValue := value.(type) {
+	case map[string]interface{}:
+		for key := range typedValue {
+			typedValue[key] = "[REDACTED]"
+		}
+	default:
+		redactSensitiveJSONFields(value)
+	}
+}
+
+func isSensitiveHeaderName(key string) bool {
+	lowerKey := strings.ToLower(key)
+	if _, ok := sensitiveHeaderNames[lowerKey]; ok {
+		return true
+	}
+
+	return strings.Contains(lowerKey, "token") ||
+		strings.Contains(lowerKey, "secret") ||
+		strings.Contains(lowerKey, "password")
 }
 
 func NewClientArgs(timeout int, baseUrl string) ClientArgs {

--- a/syntheticsclientv2/synthetics.go
+++ b/syntheticsclientv2/synthetics.go
@@ -63,6 +63,7 @@ func (c Client) String() string {
 }
 
 var sensitiveJSONFieldNames = map[string]struct{}{
+	"body":     {},
 	"content":  {},
 	"password": {},
 	"value":    {},
@@ -146,7 +147,33 @@ func redactSensitiveValue(value string, sensitiveValue string) string {
 
 func sanitizeRequestDump(requestDump string, apiKey string, _ string) string {
 	sanitizedRequestDump := redactSensitiveValue(requestDump, apiKey)
+	sanitizedRequestDump = redactRequestDumpURLQuery(sanitizedRequestDump)
 	return redactSensitiveRequestBody(sanitizedRequestDump)
+}
+
+func redactRequestDumpURLQuery(requestDump string) string {
+	lineEnd := strings.Index(requestDump, "\n")
+	if lineEnd == -1 {
+		return redactRequestLineURLQuery(requestDump)
+	}
+
+	return redactRequestLineURLQuery(requestDump[:lineEnd]) + requestDump[lineEnd:]
+}
+
+func redactRequestLineURLQuery(requestLine string) string {
+	lineSuffix := ""
+	if strings.HasSuffix(requestLine, "\r") {
+		requestLine = strings.TrimSuffix(requestLine, "\r")
+		lineSuffix = "\r"
+	}
+
+	requestLineParts := strings.SplitN(requestLine, " ", 3)
+	if len(requestLineParts) != 3 {
+		return requestLine + lineSuffix
+	}
+
+	requestLineParts[1] = redactURLQueryValues(requestLineParts[1])
+	return strings.Join(requestLineParts, " ") + lineSuffix
 }
 
 func redactSensitiveRequestBody(requestDump string) string {
@@ -197,6 +224,12 @@ func redactSensitiveJSONFields(value interface{}) {
 				typedValue[key] = "[REDACTED]"
 				continue
 			}
+			if strings.EqualFold(key, "url") {
+				if urlValue, ok := nestedValue.(string); ok {
+					typedValue[key] = redactURLQueryValues(urlValue)
+					continue
+				}
+			}
 			if strings.EqualFold(key, "headers") {
 				redactHeaderValues(nestedValue)
 				continue
@@ -230,6 +263,42 @@ func isSensitiveHeaderName(key string) bool {
 	return strings.Contains(lowerKey, "token") ||
 		strings.Contains(lowerKey, "secret") ||
 		strings.Contains(lowerKey, "password")
+}
+
+func redactURLQueryValues(rawURL string) string {
+	queryStart := strings.Index(rawURL, "?")
+	if queryStart == -1 || queryStart == len(rawURL)-1 {
+		return rawURL
+	}
+
+	prefix := rawURL[:queryStart+1]
+	query := rawURL[queryStart+1:]
+	fragment := ""
+	if fragmentStart := strings.Index(query, "#"); fragmentStart != -1 {
+		fragment = query[fragmentStart:]
+		query = query[:fragmentStart]
+	}
+	if query == "" {
+		return rawURL
+	}
+
+	queryParts := strings.Split(query, "&")
+	for i, queryPart := range queryParts {
+		if queryPart == "" {
+			continue
+		}
+		key := queryPart
+		if equalSign := strings.Index(queryPart, "="); equalSign != -1 {
+			key = queryPart[:equalSign]
+		}
+		if key == "" {
+			queryParts[i] = "[REDACTED]"
+			continue
+		}
+		queryParts[i] = key + "=[REDACTED]"
+	}
+
+	return prefix + strings.Join(queryParts, "&") + fragment
 }
 
 func NewClientArgs(timeout int, baseUrl string) ClientArgs {

--- a/syntheticsclientv2/synthetics.go
+++ b/syntheticsclientv2/synthetics.go
@@ -272,20 +272,21 @@ func isURLFieldName(key string) bool {
 }
 
 func redactURLQueryValues(rawURL string) string {
-	queryStart := strings.Index(rawURL, "?")
-	if queryStart == -1 || queryStart == len(rawURL)-1 {
-		return rawURL
+	redactedURL := redactURLUserinfo(rawURL)
+	queryStart := strings.Index(redactedURL, "?")
+	if queryStart == -1 || queryStart == len(redactedURL)-1 {
+		return redactedURL
 	}
 
-	prefix := rawURL[:queryStart+1]
-	query := rawURL[queryStart+1:]
+	prefix := redactedURL[:queryStart+1]
+	query := redactedURL[queryStart+1:]
 	fragment := ""
 	if fragmentStart := strings.Index(query, "#"); fragmentStart != -1 {
 		fragment = query[fragmentStart:]
 		query = query[:fragmentStart]
 	}
 	if query == "" {
-		return rawURL
+		return redactedURL
 	}
 
 	queryParts := strings.Split(query, "&")
@@ -305,6 +306,31 @@ func redactURLQueryValues(rawURL string) string {
 	}
 
 	return prefix + strings.Join(queryParts, "&") + fragment
+}
+
+func redactURLUserinfo(rawURL string) string {
+	authorityStart := strings.Index(rawURL, "://")
+	if authorityStart == -1 {
+		if !strings.HasPrefix(rawURL, "//") {
+			return rawURL
+		}
+		authorityStart = 2
+	} else {
+		authorityStart += len("://")
+	}
+
+	authorityEnd := len(rawURL)
+	for _, separator := range []string{"/", "?", "#"} {
+		if index := strings.Index(rawURL[authorityStart:], separator); index != -1 && authorityStart+index < authorityEnd {
+			authorityEnd = authorityStart + index
+		}
+	}
+
+	if atSign := strings.LastIndex(rawURL[authorityStart:authorityEnd], "@"); atSign != -1 {
+		return rawURL[:authorityStart] + "[REDACTED]@" + rawURL[authorityStart+atSign+1:]
+	}
+
+	return rawURL
 }
 
 func NewClientArgs(timeout int, baseUrl string) ClientArgs {

--- a/syntheticsclientv2/synthetics.go
+++ b/syntheticsclientv2/synthetics.go
@@ -225,7 +225,7 @@ func redactSensitiveJSONFields(value interface{}) {
 				typedValue[key] = "[REDACTED]"
 				continue
 			}
-			if strings.EqualFold(key, "url") {
+			if isURLFieldName(key) {
 				if urlValue, ok := nestedValue.(string); ok {
 					typedValue[key] = redactURLQueryValues(urlValue)
 					continue
@@ -264,6 +264,11 @@ func isSensitiveHeaderName(key string) bool {
 	return strings.Contains(lowerKey, "token") ||
 		strings.Contains(lowerKey, "secret") ||
 		strings.Contains(lowerKey, "password")
+}
+
+func isURLFieldName(key string) bool {
+	lowerKey := strings.ToLower(key)
+	return lowerKey == "url" || strings.HasSuffix(lowerKey, "url")
 }
 
 func redactURLQueryValues(rawURL string) string {

--- a/syntheticsclientv2/synthetics.go
+++ b/syntheticsclientv2/synthetics.go
@@ -66,6 +66,7 @@ var sensitiveJSONFieldNames = map[string]struct{}{
 	"body":     {},
 	"content":  {},
 	"password": {},
+	"username": {},
 	"value":    {},
 }
 

--- a/syntheticsclientv2/synthetics_test.go
+++ b/syntheticsclientv2/synthetics_test.go
@@ -351,17 +351,20 @@ func TestSanitizeRequestDumpRedactsAPIAndHTTPCheckBodyFields(t *testing.T) {
 
 func TestSanitizeRequestDumpRedactsURLQueryValues(t *testing.T) {
 	requestDump := "POST /tests/http?trace=client-query-secret&limit=25 HTTP/1.1\r\nHost: example.com\r\nX-SF-TOKEN: client-api-key\r\n\r\n" +
-		`{"test":{"startUrl":"https://browser.example/start?login_token=browser-start-token&continue=browser-start-continue","url":"https://target.example/login?token=url-token-secret&tenant=tenant-secret","requests":[{"configuration":{"url":"https://api.example/search?api_key=api-url-secret&q=customer-secret"}}]}}`
+		`{"test":{"startUrl":"https://browser-user:browser-password@browser.example/start?login_token=browser-start-token&continue=browser-start-continue","url":"https://target-user:target-password@target.example/login?token=url-token-secret&tenant=tenant-secret","callbackUrl":"https://callback-user:callback-password@callback.example/path","requests":[{"configuration":{"url":"https://api.example/search?api_key=api-url-secret&q=customer-secret"}}]}}`
 
 	sanitized := sanitizeRequestDump(requestDump, "client-api-key", "/tests/http")
 
-	for _, secret := range []string{"client-api-key", "client-query-secret", "25", "browser-start-token", "browser-start-continue", "url-token-secret", "tenant-secret", "api-url-secret", "customer-secret"} {
+	for _, secret := range []string{"client-api-key", "client-query-secret", "25", "browser-user", "browser-password", "browser-start-token", "browser-start-continue", "target-user", "target-password", "url-token-secret", "tenant-secret", "callback-user", "callback-password", "api-url-secret", "customer-secret"} {
 		if strings.Contains(sanitized, secret) {
 			t.Fatalf("sanitized request dump leaked %q: %s", secret, sanitized)
 		}
 	}
 	for _, redacted := range []string{
 		"/tests/http?trace=[REDACTED]&limit=[REDACTED]",
+		"[REDACTED]@browser.example",
+		"[REDACTED]@target.example",
+		"[REDACTED]@callback.example",
 		"login_token=[REDACTED]",
 		"continue=[REDACTED]",
 		"token=[REDACTED]",

--- a/syntheticsclientv2/synthetics_test.go
+++ b/syntheticsclientv2/synthetics_test.go
@@ -351,17 +351,19 @@ func TestSanitizeRequestDumpRedactsAPIAndHTTPCheckBodyFields(t *testing.T) {
 
 func TestSanitizeRequestDumpRedactsURLQueryValues(t *testing.T) {
 	requestDump := "POST /tests/http?trace=client-query-secret&limit=25 HTTP/1.1\r\nHost: example.com\r\nX-SF-TOKEN: client-api-key\r\n\r\n" +
-		`{"test":{"url":"https://target.example/login?token=url-token-secret&tenant=tenant-secret","requests":[{"configuration":{"url":"https://api.example/search?api_key=api-url-secret&q=customer-secret"}}]}}`
+		`{"test":{"startUrl":"https://browser.example/start?login_token=browser-start-token&continue=browser-start-continue","url":"https://target.example/login?token=url-token-secret&tenant=tenant-secret","requests":[{"configuration":{"url":"https://api.example/search?api_key=api-url-secret&q=customer-secret"}}]}}`
 
 	sanitized := sanitizeRequestDump(requestDump, "client-api-key", "/tests/http")
 
-	for _, secret := range []string{"client-api-key", "client-query-secret", "25", "url-token-secret", "tenant-secret", "api-url-secret", "customer-secret"} {
+	for _, secret := range []string{"client-api-key", "client-query-secret", "25", "browser-start-token", "browser-start-continue", "url-token-secret", "tenant-secret", "api-url-secret", "customer-secret"} {
 		if strings.Contains(sanitized, secret) {
 			t.Fatalf("sanitized request dump leaked %q: %s", secret, sanitized)
 		}
 	}
 	for _, redacted := range []string{
 		"/tests/http?trace=[REDACTED]&limit=[REDACTED]",
+		"login_token=[REDACTED]",
+		"continue=[REDACTED]",
 		"token=[REDACTED]",
 		"tenant=[REDACTED]",
 		"api_key=[REDACTED]",

--- a/syntheticsclientv2/synthetics_test.go
+++ b/syntheticsclientv2/synthetics_test.go
@@ -333,6 +333,46 @@ func TestSanitizeRequestDumpRedactsAllAPIHeaderMapValues(t *testing.T) {
 	}
 }
 
+func TestSanitizeRequestDumpRedactsAPIAndHTTPCheckBodyFields(t *testing.T) {
+	requestDump := "POST /tests/api HTTP/1.1\r\nHost: example.com\r\nX-SF-TOKEN: client-api-key\r\n\r\n" +
+		`{"test":{"requests":[{"configuration":{"name":"login","body":"client_secret=api-body-secret&password=api-password-secret"}}],"body":"password=http-body-secret"}}`
+
+	sanitized := sanitizeRequestDump(requestDump, "client-api-key", "/tests/api")
+
+	for _, secret := range []string{"client-api-key", "api-body-secret", "api-password-secret", "http-body-secret"} {
+		if strings.Contains(sanitized, secret) {
+			t.Fatalf("sanitized request dump leaked %q: %s", secret, sanitized)
+		}
+	}
+	if got := strings.Count(sanitized, `"body":"[REDACTED]"`); got != 2 {
+		t.Fatalf("expected both API and HTTP check body fields to be redacted, saw %d redactions in: %s", got, sanitized)
+	}
+}
+
+func TestSanitizeRequestDumpRedactsURLQueryValues(t *testing.T) {
+	requestDump := "POST /tests/http?trace=client-query-secret&limit=25 HTTP/1.1\r\nHost: example.com\r\nX-SF-TOKEN: client-api-key\r\n\r\n" +
+		`{"test":{"url":"https://target.example/login?token=url-token-secret&tenant=tenant-secret","requests":[{"configuration":{"url":"https://api.example/search?api_key=api-url-secret&q=customer-secret"}}]}}`
+
+	sanitized := sanitizeRequestDump(requestDump, "client-api-key", "/tests/http")
+
+	for _, secret := range []string{"client-api-key", "client-query-secret", "25", "url-token-secret", "tenant-secret", "api-url-secret", "customer-secret"} {
+		if strings.Contains(sanitized, secret) {
+			t.Fatalf("sanitized request dump leaked %q: %s", secret, sanitized)
+		}
+	}
+	for _, redacted := range []string{
+		"/tests/http?trace=[REDACTED]&limit=[REDACTED]",
+		"token=[REDACTED]",
+		"tenant=[REDACTED]",
+		"api_key=[REDACTED]",
+		"q=[REDACTED]",
+	} {
+		if !strings.Contains(sanitized, redacted) {
+			t.Fatalf("sanitized request dump missing %q: %s", redacted, sanitized)
+		}
+	}
+}
+
 func TestMakePublicAPICallDoesNotExposeRawRequest(t *testing.T) {
 	testMux = http.NewServeMux()
 	testServer = httptest.NewServer(testMux)

--- a/syntheticsclientv2/synthetics_test.go
+++ b/syntheticsclientv2/synthetics_test.go
@@ -315,6 +315,24 @@ func TestSanitizeRequestDumpRedactsHeaderCookieAndAuthenticationValues(t *testin
 	}
 }
 
+func TestSanitizeRequestDumpRedactsAllAPIHeaderMapValues(t *testing.T) {
+	requestDump := "POST /v2/tests/api HTTP/1.1\r\nHost: example.com\r\nX-SF-TOKEN: client-api-key\r\n\r\n" +
+		`{"test":{"requests":[{"configuration":{"headers":{"X-SF-TOKEN":"request-token","Accept":"accept-json-secret","beep":"plain-header-secret"},"body":null}}]}}`
+
+	sanitized := sanitizeRequestDump(requestDump, "client-api-key", "/v2/tests/api")
+
+	for _, secret := range []string{"client-api-key", "request-token", "accept-json-secret", "plain-header-secret"} {
+		if strings.Contains(sanitized, secret) {
+			t.Fatalf("sanitized request dump leaked %q: %s", secret, sanitized)
+		}
+	}
+	for _, redacted := range []string{`"X-SF-TOKEN":"[REDACTED]"`, `"Accept":"[REDACTED]"`, `"beep":"[REDACTED]"`} {
+		if !strings.Contains(sanitized, redacted) {
+			t.Fatalf("sanitized request dump missing %q: %s", redacted, sanitized)
+		}
+	}
+}
+
 func TestMakePublicAPICallDoesNotExposeRawRequest(t *testing.T) {
 	testMux = http.NewServeMux()
 	testServer = httptest.NewServer(testMux)

--- a/syntheticsclientv2/synthetics_test.go
+++ b/syntheticsclientv2/synthetics_test.go
@@ -299,16 +299,16 @@ func TestSanitizeRequestDumpRedactsHeadersAndSecretJSONFields(t *testing.T) {
 
 func TestSanitizeRequestDumpRedactsHeaderCookieAndAuthenticationValues(t *testing.T) {
 	requestDump := "PUT /tests/browser/123 HTTP/1.1\r\nX-Sf-Token: token-abc\r\n\r\n" +
-		`{"test":{"advancedSettings":{"headers":[{"name":"Authorization","value":"Bearer secret"}],"cookies":[{"name":"session","value":"cookie-secret"}],"authentication":{"password":"auth-secret"}}}}`
+		`{"test":{"advancedSettings":{"headers":[{"name":"Authorization","value":"Bearer secret"}],"cookies":[{"name":"session","value":"cookie-secret"}],"authentication":{"username":"auth-user-secret","password":"auth-secret"}}}}`
 
 	sanitized := sanitizeRequestDump(requestDump, "token-abc", "/tests/browser/123")
 
-	for _, secret := range []string{"token-abc", "Bearer secret", "cookie-secret", "auth-secret"} {
+	for _, secret := range []string{"token-abc", "Bearer secret", "cookie-secret", "auth-user-secret", "auth-secret"} {
 		if strings.Contains(sanitized, secret) {
 			t.Fatalf("sanitized request dump leaked %q: %s", secret, sanitized)
 		}
 	}
-	for _, redacted := range []string{`"value":"[REDACTED]"`, `"password":"[REDACTED]"`, "X-Sf-Token: [REDACTED]"} {
+	for _, redacted := range []string{`"value":"[REDACTED]"`, `"username":"[REDACTED]"`, `"password":"[REDACTED]"`, "X-Sf-Token: [REDACTED]"} {
 		if !strings.Contains(sanitized, redacted) {
 			t.Fatalf("sanitized request dump missing %q: %s", redacted, sanitized)
 		}

--- a/syntheticsclientv2/update_browsercheckv2_test.go
+++ b/syntheticsclientv2/update_browsercheckv2_test.go
@@ -162,6 +162,75 @@ func TestUpdateBrowserCheckV2SerializesCertificateIDs(t *testing.T) {
 	assertBrowserCheckV2RequestCertificateIDs(t, advancedSettings, []int{123})
 }
 
+func TestUpdateBrowserCheckV2PreservesAdvancedSettingsFields(t *testing.T) {
+	userAgent := "syntheticsclient-test-agent"
+	input := BrowserCheckV2Input{}
+	input.Test.Name = "browser-advanced-settings"
+	input.Test.Authentication = &Authentication{
+		Username: "browser-user",
+		Password: "browser-password",
+	}
+	input.Test.Cookiesv2 = []Cookiesv2{
+		{
+			Key:    "session",
+			Value:  "cookie-value",
+			Domain: "example.com",
+			Path:   "/",
+		},
+	}
+	input.Test.BrowserHeaders = []BrowserHeaders{
+		{
+			Name:   "X-Test-Header",
+			Value:  "header-value",
+			Domain: "example.com",
+		},
+	}
+	input.Test.HostOverrides = []HostOverrides{
+		{
+			Source:         "source.example.com",
+			Target:         "target.example.com",
+			KeepHostHeader: true,
+		},
+	}
+	input.Test.UserAgent = &userAgent
+	input.Test.CollectInteractiveMetrics = true
+	input.Test.Verifycertificates = true
+	input.Test.ChromeFlags = []ChromeFlag{
+		{
+			Name:  "--proxy-bypass-list",
+			Value: "127.0.0.1:8080",
+		},
+	}
+	input.Test.ExcludedFiles = []ExcludedFile{
+		{
+			Type:  "custom",
+			Regex: "example.com",
+		},
+	}
+
+	requestBody := captureUpdateBrowserCheckV2RequestBody(t, input)
+
+	advancedSettings := browserCheckV2RequestAdvancedSettingsPayload(t, requestBody)
+	expectedAdvancedSettingsJSON, err := json.Marshal(input.Test.Advancedsettings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var expectedAdvancedSettings map[string]interface{}
+	if err := json.Unmarshal(expectedAdvancedSettingsJSON, &expectedAdvancedSettings); err != nil {
+		t.Fatal(err)
+	}
+
+	for key, expected := range expectedAdvancedSettings {
+		actual, ok := advancedSettings[key]
+		if !ok {
+			t.Fatalf("expected advancedSettings.%s to be preserved in request body: %s", key, requestBody)
+		}
+		if !reflect.DeepEqual(actual, expected) {
+			t.Fatalf("expected advancedSettings.%s to be %#v, but saw %#v in body: %s", key, expected, actual, requestBody)
+		}
+	}
+}
+
 func TestUpdateBrowserCheckV2(t *testing.T) {
 	setup()
 	defer teardown()

--- a/syntheticsclientv2/update_browsercheckv2_test.go
+++ b/syntheticsclientv2/update_browsercheckv2_test.go
@@ -20,8 +20,10 @@ package syntheticsclientv2
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -29,6 +31,75 @@ var (
 	updateBrowserCheckV2Body  = `{"test":{"automaticRetries": 1, "customProperties": [{"key": "Test_Key", "value": "Test Custom Properties"}], "name":"browser-beep-test","transactions":[{"name":"Synthetic transaction 1","steps":[{"name":"Go to URL","type":"go_to_url","url":"https://splunk.com","action":"go_to_url","options":{"url":"https://splunk.com"}},{"name":"click","type":"click_element","selectors":[{"type":"id","value":"clicky"}],"waitForNav":true,"waitForNavTimeout":2000},{"name":"fill in fieldz","type":"enter_value","selectors":[{"type":"id","value":"beep"}],"value":"{{env.beep-var}}","waitForNav":false,"waitForNavTimeout":50},{"name":"accept---Alert","type":"accept_alert"},{"name":"Select-Val-Index","type":"select_option","selectors":[{"type":"id","value":"selectionz"}],"optionSelectorType":"index","optionSelector":"{{env.beep-var}}","waitForNav":false,"waitForNavTimeout":50},{"name":"Select-val-text","type":"select_option","selectors":[{"type":"id","value":"textzz"}],"optionSelectorType":"text","optionSelector":"sdad","waitForNav":false,"waitForNavTimeout":50},{"name":"Select-Val-Val","type":"select_option","selectors":[{"type":"id","value":"valz"}],"optionSelectorType":"value","optionSelector":"{{env.beep-var}}","waitForNav":false,"waitForNavTimeout":50},{"name":"Run JS","type":"run_javascript","value":"beeeeeeep","waitForNav":true,"waitForNavTimeout":2000},{"name":"Save as text","type":"store_variable_from_element","selectors":[{"type":"link","value":"beepval"}],"variableName":"{{env.terraform-test-foo-301}}"},{"name":"Save JS return Val","type":"store_variable_from_javascript","value":"sdasds","variableName":"{{env.terraform-test-foo-301}}","waitForNav":true,"waitForNavTimeout":2000}]}],"urlProtocol":"https://","startUrl":"www.splunk.com","locationIds":["aws-us-east-1"],"deviceId":1,"frequency":15,"schedulingStrategy":"round_robin","active":true,"advancedSettings":{"verifyCertificates":true,"authentication":{"username":"boopuser","password":"{{env.beep-var}}"},"headers":[{"name":"batman","value":"Agentoz","domain":"www.batmansagent.com"}],"chromeFlags":[{"name":"--proxy-bypass-list","value":"127.0.0.1:8080"}],"cookies":[{"key":"super","value":"duper","domain":"www.batmansagent.com","path":"/boom/goes/beep"}],"excludedFiles":[{"type":"google_analytics"},{"type":"custom","regex":"some-domain.com"},{"type":"all_except","regex":"another-domain.com"}]}}}`
 	inputBrowserCheckV2Update = BrowserCheckV2Input{}
 )
+
+func captureUpdateBrowserCheckV2RequestBody(t *testing.T, input BrowserCheckV2Input) string {
+	t.Helper()
+
+	setup()
+	defer teardown()
+
+	var requestBody string
+	testMux.HandleFunc("/v2/tests/browser/10", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		requestBody = string(bodyBytes)
+
+		_, err = w.Write([]byte(updateBrowserCheckV2Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	_, _, err := testClient.UpdateBrowserCheckV2(10, &input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return requestBody
+}
+
+func TestUpdateBrowserCheckV2OmitsUnsetCertificateIDs(t *testing.T) {
+	input := BrowserCheckV2Input{}
+	input.Test.Name = "browser-without-certs"
+
+	requestBody := captureUpdateBrowserCheckV2RequestBody(t, input)
+
+	if strings.Contains(requestBody, "certificateIds") {
+		t.Fatalf("expected request body to omit unset certificateIds, but saw: %s", requestBody)
+	}
+}
+
+func TestUpdateBrowserCheckV2SerializesEmptyCertificateIDs(t *testing.T) {
+	input := BrowserCheckV2Input{}
+	input.Test.Name = "browser-clear-certs"
+	certificateIDs := []int{}
+	input.Test.CertificateIDs = certificateIDs
+
+	requestBody := captureUpdateBrowserCheckV2RequestBody(t, input)
+
+	if !strings.Contains(requestBody, `"certificateIds":[]`) {
+		t.Fatalf("expected request body to include empty certificateIds array, but saw: %s", requestBody)
+	}
+	if strings.Contains(requestBody, `"certificateIds":null`) {
+		t.Fatalf("expected empty certificateIds array, not null, but saw: %s", requestBody)
+	}
+}
+
+func TestUpdateBrowserCheckV2SerializesCertificateIDs(t *testing.T) {
+	input := BrowserCheckV2Input{}
+	input.Test.Name = "browser-attach-certs"
+	certificateIDs := []int{123}
+	input.Test.CertificateIDs = certificateIDs
+
+	requestBody := captureUpdateBrowserCheckV2RequestBody(t, input)
+
+	if !strings.Contains(requestBody, `"certificateIds":[123]`) {
+		t.Fatalf("expected request body to include populated certificateIds array, but saw: %s", requestBody)
+	}
+}
 
 func TestUpdateBrowserCheckV2(t *testing.T) {
 	setup()

--- a/syntheticsclientv2/update_browsercheckv2_test.go
+++ b/syntheticsclientv2/update_browsercheckv2_test.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"net/http"
 	"reflect"
-	"strings"
 	"testing"
 )
 
@@ -61,14 +60,73 @@ func captureUpdateBrowserCheckV2RequestBody(t *testing.T, input BrowserCheckV2In
 	return requestBody
 }
 
+func browserCheckV2RequestTestPayload(t *testing.T, requestBody string) map[string]interface{} {
+	t.Helper()
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(requestBody), &payload); err != nil {
+		t.Fatalf("expected request body to be valid JSON, but saw error %s for body: %s", err, requestBody)
+	}
+
+	testPayload, ok := payload["test"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected request body to contain test object, but saw: %s", requestBody)
+	}
+
+	return testPayload
+}
+
+func browserCheckV2RequestAdvancedSettingsPayload(t *testing.T, requestBody string) map[string]interface{} {
+	t.Helper()
+
+	testPayload := browserCheckV2RequestTestPayload(t, requestBody)
+	if _, ok := testPayload["certificateIds"]; ok {
+		t.Fatalf("expected certificateIds under advancedSettings, not directly under test: %s", requestBody)
+	}
+
+	advancedSettings, ok := testPayload["advancedSettings"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected request body to contain advancedSettings object, but saw: %s", requestBody)
+	}
+
+	return advancedSettings
+}
+
+func assertBrowserCheckV2RequestCertificateIDs(t *testing.T, advancedSettings map[string]interface{}, expected []int) {
+	t.Helper()
+
+	certificateIDs, ok := advancedSettings["certificateIds"].([]interface{})
+	if !ok {
+		t.Fatalf("expected advancedSettings.certificateIds array, but saw: %#v", advancedSettings["certificateIds"])
+	}
+	if len(certificateIDs) != len(expected) {
+		t.Fatalf("expected %d certificateIds, but saw %d: %#v", len(expected), len(certificateIDs), certificateIDs)
+	}
+	for i, expectedID := range expected {
+		actualID, ok := certificateIDs[i].(float64)
+		if !ok || int(actualID) != expectedID {
+			t.Fatalf("expected certificateIds[%d] to be %d, but saw %#v", i, expectedID, certificateIDs[i])
+		}
+	}
+}
+
 func TestUpdateBrowserCheckV2OmitsUnsetCertificateIDs(t *testing.T) {
 	input := BrowserCheckV2Input{}
 	input.Test.Name = "browser-without-certs"
 
 	requestBody := captureUpdateBrowserCheckV2RequestBody(t, input)
 
-	if strings.Contains(requestBody, "certificateIds") {
-		t.Fatalf("expected request body to omit unset certificateIds, but saw: %s", requestBody)
+	testPayload := browserCheckV2RequestTestPayload(t, requestBody)
+	if got := testPayload["name"]; got != "browser-without-certs" {
+		t.Fatalf("expected request body to preserve browser test name, but saw %#v in body: %s", got, requestBody)
+	}
+	if _, ok := testPayload["certificateIds"]; ok {
+		t.Fatalf("expected request body to omit certificateIds directly under test, but saw: %s", requestBody)
+	}
+	if advancedSettings, ok := testPayload["advancedSettings"].(map[string]interface{}); ok {
+		if _, ok := advancedSettings["certificateIds"]; ok {
+			t.Fatalf("expected request body to omit unset advancedSettings.certificateIds, but saw: %s", requestBody)
+		}
 	}
 }
 
@@ -80,12 +138,12 @@ func TestUpdateBrowserCheckV2SerializesEmptyCertificateIDs(t *testing.T) {
 
 	requestBody := captureUpdateBrowserCheckV2RequestBody(t, input)
 
-	if !strings.Contains(requestBody, `"certificateIds":[]`) {
-		t.Fatalf("expected request body to include empty certificateIds array, but saw: %s", requestBody)
+	testPayload := browserCheckV2RequestTestPayload(t, requestBody)
+	if got := testPayload["name"]; got != "browser-clear-certs" {
+		t.Fatalf("expected request body to preserve browser test name, but saw %#v in body: %s", got, requestBody)
 	}
-	if strings.Contains(requestBody, `"certificateIds":null`) {
-		t.Fatalf("expected empty certificateIds array, not null, but saw: %s", requestBody)
-	}
+	advancedSettings := browserCheckV2RequestAdvancedSettingsPayload(t, requestBody)
+	assertBrowserCheckV2RequestCertificateIDs(t, advancedSettings, []int{})
 }
 
 func TestUpdateBrowserCheckV2SerializesCertificateIDs(t *testing.T) {
@@ -96,9 +154,12 @@ func TestUpdateBrowserCheckV2SerializesCertificateIDs(t *testing.T) {
 
 	requestBody := captureUpdateBrowserCheckV2RequestBody(t, input)
 
-	if !strings.Contains(requestBody, `"certificateIds":[123]`) {
-		t.Fatalf("expected request body to include populated certificateIds array, but saw: %s", requestBody)
+	testPayload := browserCheckV2RequestTestPayload(t, requestBody)
+	if got := testPayload["name"]; got != "browser-attach-certs" {
+		t.Fatalf("expected request body to preserve browser test name, but saw %#v in body: %s", got, requestBody)
 	}
+	advancedSettings := browserCheckV2RequestAdvancedSettingsPayload(t, requestBody)
+	assertBrowserCheckV2RequestCertificateIDs(t, advancedSettings, []int{123})
 }
 
 func TestUpdateBrowserCheckV2(t *testing.T) {


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves #SYN-6770

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Sanitized v2 request details could still expose API-check header-map values such as `X-SF-TOKEN`.
* Browser update payloads could not send explicit `certificateIds:[]` to clear attached client certificates.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* All values under JSON `headers` maps are redacted in sanitized request details.
* Existing `content`, `password`, and `value` request-body redaction is preserved.
* Browser update payloads can distinguish omitted `certificateIds` from explicit `certificateIds:[]` without changing the public `CertificateIDs []int` field type.

### Pull request checklist 
- [x] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
<!-- Please paste the results of acceptance tests `make testacc` in the codeblock here. -->

```text
PASS
coverage: 72.8% of statements
ok  	github.com/splunk/syntheticsclient/v2/syntheticsclientv2	1.431s	coverage: 72.8% of statements

```

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----
