### PR TITLE
Fix SSL last run ID type

### DIFF
--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -585,7 +585,7 @@ type SslCheckV2Response struct {
 		Lastrunat                     time.Time          `json:"lastRunAt"`
 		LastRunCoreMetricsPublishedAt time.Time          `json:"lastRunCoreMetricsPublishedAt"`
 		LastRunLocationId             string             `json:"lastRunLocationId"`
-		LastRunId                     int                `json:"lastRunId"`
+		LastRunId                     string             `json:"lastRunId"`
 		Automaticretries              int                `json:"automaticRetries"`
 		Createdby                     string             `json:"createdBy"`
 		Updatedby                     string             `json:"updatedBy"`

--- a/syntheticsclientv2/get_sslcheckv2_test.go
+++ b/syntheticsclientv2/get_sslcheckv2_test.go
@@ -25,8 +25,10 @@ import (
 	"testing"
 )
 
+const getSslCheckV2LastRunID = "77ff08f0-3865-42d8-9fff-3efb7c25e176"
+
 var (
-	getSslCheckV2Body  = `{"test":{"id":1647,"type":"ssl","name":"ssl-check","frequency":5,"schedulingStrategy":"round_robin","active":true,"locationIds":["aws-us-east-1"],"createdAt":"2022-09-14T14:35:37.801Z","updatedAt":"2022-09-14T14:35:38.099Z","createdBy":"abc1234","updatedBy":"abc1234","customProperties":[{"key":"env","value":"prod"}],"automaticRetries":1,"lastRunStatus":"success","lastRunAt":"2024-03-07T00:47:43.741Z","lastRunCoreMetricsPublishedAt":"2024-03-07T00:47:43.741Z","lastRunLocationId":"aws-us-east-1","lastRunId":999,"host":"www.splunk.com","port":443,"serverName":"www.splunk.com","allowSelfSigned":true,"allowUntrustedRoot":false,"caCertificateId":42,"validations":[{"name":"Certificate expires later","type":"assert_numeric","actual":"{{certificate.days_until_expiration}}","expected":"30","comparator":"is_greater_than"}]}}`
+	getSslCheckV2Body  = `{"test":{"id":1647,"type":"ssl","name":"ssl-check","frequency":5,"schedulingStrategy":"round_robin","active":true,"locationIds":["aws-us-east-1"],"createdAt":"2022-09-14T14:35:37.801Z","updatedAt":"2022-09-14T14:35:38.099Z","createdBy":"abc1234","updatedBy":"abc1234","customProperties":[{"key":"env","value":"prod"}],"automaticRetries":1,"lastRunStatus":"success","lastRunAt":"2024-03-07T00:47:43.741Z","lastRunCoreMetricsPublishedAt":"2024-03-07T00:47:43.741Z","lastRunLocationId":"aws-us-east-1","lastRunId":"` + getSslCheckV2LastRunID + `","host":"www.splunk.com","port":443,"serverName":"www.splunk.com","allowSelfSigned":true,"allowUntrustedRoot":false,"caCertificateId":42,"validations":[{"name":"Certificate expires later","type":"assert_numeric","actual":"{{certificate.days_until_expiration}}","expected":"30","comparator":"is_greater_than"}]}}`
 	inputGetSslCheckV2 = verifySslCheckV2Input(string(getSslCheckV2Body))
 )
 
@@ -49,6 +51,9 @@ func TestGetSslCheckV2(t *testing.T) {
 
 	if !reflect.DeepEqual(resp.Test.ID, inputGetSslCheckV2.Test.ID) {
 		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.ID, inputGetSslCheckV2.Test.ID)
+	}
+	if resp.Test.LastRunId != getSslCheckV2LastRunID {
+		t.Errorf("returned last run ID %q, want %q", resp.Test.LastRunId, getSslCheckV2LastRunID)
 	}
 	if !reflect.DeepEqual(resp.Test.Name, inputGetSslCheckV2.Test.Name) {
 		t.Errorf("returned \n\n%#v want \n\n%#v", resp.Test.Name, inputGetSslCheckV2.Test.Name)


### PR DESCRIPTION
Related to splunk/terraform-provider-synthetics#94

----

### Before the change?

* `SslCheckV2Response.Test.LastRunId` was modeled as an `int`.
* The Synthetics API returns `lastRunId` as a UUID string, so decoding an SSL check response could fail with `cannot unmarshal string into Go struct field ...lastRunId of type int`.

### After the change?

* Model SSL check `lastRunId` values as strings.
* Exercise a UUID `lastRunId` through `GetSslCheckV2` and assert that the response preserves it exactly.

### Pull request checklist

- [x] Regression test updated and the complete v2 unit test suite run
- [x] Docs reviewed; no documentation changes are needed

#### Test Output

```text
go test ./syntheticsclientv2/... -v -tags=unit_tests -timeout=30s -parallel=4 -cover

PASS
coverage: 73.5% of statements
ok github.com/splunk/syntheticsclient/v2/syntheticsclientv2 1.351s
```

Additional validation:

```text
go vet -tags=unit_tests ./syntheticsclientv2/...
```

### Does this introduce a breaking change?

- [x] Yes
- [ ] No

This changes the type of the exported `LastRunId` field from `int` to `string`. Code that assigns or compares an integer directly will need to use the API's UUID string representation instead.

----
