### PR TITLE
Use reusable Splunk agreements workflow

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -4,50 +4,15 @@ on:
     types: [created]
   pull_request_target:
     types: [opened, closed, synchronize]
-# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
-permissions:
-  actions: write
-  contents: write
-  pull-requests: write
-  statuses: write
+
 jobs:
-  CLAAssistant:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.3.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # the below token should have repo scope and must be manually added by you in the repository's secret
-          # This token is required only if you have configured to store the signatures in a remote repository/organization
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        with:
-          path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/splunk/cla-agreement/blob/main/CLA.md' # e.g. a CLA or a DCO document
-          # branch should not be protected
-          branch: 'main'
-          allowlist: dependabot[bot]
-          remote-organization-name: splunk
-          remote-repository-name: cla-agreement
-  CodeOfConduct:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "COC Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the Code of Conduct and I hereby accept the Terms') || github.event_name == 'pull_request_target'
-        uses: cla-assistant/github-action@v2.3.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        with:
-          path-to-signatures: "signatures/version1/coc.json"
-          path-to-document: "https://github.com/splunk/cla-agreement/blob/main/CODE_OF_CONDUCT.md" # e.g. a COC or a DCO document
-          branch: "main"
-          allowlist: dependabot[bot]
-          remote-organization-name: splunk
-          remote-repository-name: cla-agreement
-          custom-pr-sign-comment: "I have read the Code of Conduct and I hereby accept the Terms"
-          create-file-commit-message: "For example: Creating file for storing COC Signatures"
-          signed-commit-message: "$contributorName has signed the COC in #$pullRequestNo"
-          custom-notsigned-prcomment: "All contributors have NOT signed the COC Document"
-          custom-allsigned-prcomment: "****CLA Assistant Lite bot**** All contributors have signed the COC  ✍️ ✅"
+  call-workflow-agreements:
+    uses: splunk/addonfactory-github-workflows/.github/workflows/reusable-agreements.yaml@v1.7.2
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+      statuses: read
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.PAT_CLATOOL }}


### PR DESCRIPTION
Related to #46

----

### Before the change?

* The repository defined its CLA and Code of Conduct jobs locally with `contributor-assistant/github-action@v2.3.0`.
* Both jobs failed while reading `splunk/cla-agreement` with `Could not retrieve repository contents. Status: 401`.
* The workflow granted write access to repository contents and actions.

### After the change?

* Delegate both checks to Splunk's shared `reusable-agreements.yaml@v1.7.2` workflow, following the pattern used by `splunk-connect-for-snmp`.
* Map the centrally managed `PAT_CLATOOL` secret to the reusable workflow's `PERSONAL_ACCESS_TOKEN` input.
* Reduce caller permissions to the least-privilege set required by the shared workflow.
* Pick up `contributor-assistant/github-action@v2.6.1` through the pinned reusable workflow.

### Pull request checklist

- [x] Workflow syntax validated with `actionlint v1.7.7`
- [x] Docs reviewed; no documentation changes are needed

#### Validation Output

```text
actionlint .github/workflows/cla.yaml

# no findings
```

The agreement jobs on this PR will still use the existing base-branch workflow because `pull_request_target` loads workflow definitions from the base branch. The reusable workflow will take effect after this change is merged.

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

----
