### PR TITLE
SYN-3601: Preserve certificates with nullable HTTP ports

### DIFF
--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -740,6 +740,7 @@ type HttpCheckV2ResponseWithNullablePort struct {
 		Authentication     *Authentication    `json:"authentication"`
 		UserAgent          *string            `json:"userAgent"`
 		Verifycertificates bool               `json:"verifyCertificates"`
+		CertificateID      *NullableInt       `json:"certificateId,omitempty"`
 		HttpHeaders        []HttpHeaders      `json:"headers,omitempty"`
 		Validations        []Validations      `json:"validations"`
 		Customproperties   []CustomProperties `json:"customProperties"`
@@ -766,6 +767,7 @@ type HttpCheckV2InputWithNullablePort struct {
 		Authentication     *Authentication    `json:"authentication"`
 		UserAgent          *string            `json:"userAgent"`
 		Verifycertificates bool               `json:"verifyCertificates"`
+		CertificateID      *NullableInt       `json:"certificateId,omitempty"`
 		HttpHeaders        []HttpHeaders      `json:"headers,omitempty"`
 		Validations        []Validations      `json:"validations"`
 		Customproperties   []CustomProperties `json:"customProperties"`

--- a/syntheticsclientv2/httpcheckv2_nullable_port_test.go
+++ b/syntheticsclientv2/httpcheckv2_nullable_port_test.go
@@ -38,7 +38,14 @@ func TestCreateHttpCheckV2WithNullablePortSendsNullPort(t *testing.T) {
 		if string(rawPort) != "null" {
 			t.Fatalf("request body test.port = %s, want null", rawPort)
 		}
-		_, err := w.Write([]byte(`{"test":{"id":11,"name":"nullable-port","type":"http","url":"https://example.com","requestMethod":"GET","port":null}}`))
+		rawCertificateID, ok := fields["certificateId"]
+		if !ok {
+			t.Fatal("request body missing test.certificateId")
+		}
+		if string(rawCertificateID) != "123" {
+			t.Fatalf("request body test.certificateId = %s, want 123", rawCertificateID)
+		}
+		_, err := w.Write([]byte(`{"test":{"id":11,"name":"nullable-port","type":"http","url":"https://example.com","requestMethod":"GET","port":null,"certificateId":123}}`))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -46,6 +53,7 @@ func TestCreateHttpCheckV2WithNullablePortSendsNullPort(t *testing.T) {
 
 	input := minimalHttpCheckV2InputWithNullablePort()
 	input.Test.Port = *NewNullInt()
+	input.Test.CertificateID = NewNullableInt(123)
 
 	resp, _, err := testClient.CreateHttpCheckV2WithNullablePort(&input)
 	if err != nil {
@@ -53,6 +61,9 @@ func TestCreateHttpCheckV2WithNullablePortSendsNullPort(t *testing.T) {
 	}
 	if resp.Test.Port.Value != nil {
 		t.Fatalf("response port = %#v, want nil", resp.Test.Port.Value)
+	}
+	if resp.Test.CertificateID == nil || resp.Test.CertificateID.Value == nil || *resp.Test.CertificateID.Value != 123 {
+		t.Fatalf("response certificate ID = %#v, want 123", resp.Test.CertificateID)
 	}
 }
 
@@ -70,6 +81,13 @@ func TestUpdateHttpCheckV2WithNullablePortSendsZeroPort(t *testing.T) {
 		if string(rawPort) != "0" {
 			t.Fatalf("request body test.port = %s, want 0", rawPort)
 		}
+		rawCertificateID, ok := fields["certificateId"]
+		if !ok {
+			t.Fatal("request body missing test.certificateId")
+		}
+		if string(rawCertificateID) != "null" {
+			t.Fatalf("request body test.certificateId = %s, want null", rawCertificateID)
+		}
 		_, err := w.Write([]byte(`{"test":{"id":12,"name":"nullable-port","type":"http","url":"https://example.com","requestMethod":"GET","port":0}}`))
 		if err != nil {
 			t.Fatal(err)
@@ -78,6 +96,7 @@ func TestUpdateHttpCheckV2WithNullablePortSendsZeroPort(t *testing.T) {
 
 	input := minimalHttpCheckV2InputWithNullablePort()
 	input.Test.Port = *NewNullableInt(0)
+	input.Test.CertificateID = NewNullInt()
 
 	resp, _, err := testClient.UpdateHttpCheckV2WithNullablePort(12, &input)
 	if err != nil {
@@ -102,7 +121,7 @@ func TestGetHttpCheckV2WithNullablePortPreservesNullAndValue(t *testing.T) {
 		},
 		{
 			name:      "value",
-			body:      `{"test":{"id":13,"name":"nullable-port","type":"http","url":"https://example.com","requestMethod":"GET","port":443}}`,
+			body:      `{"test":{"id":13,"name":"nullable-port","type":"http","url":"https://example.com","requestMethod":"GET","port":443,"certificateId":123}}`,
 			wantValue: 443,
 		},
 	}
@@ -132,6 +151,9 @@ func TestGetHttpCheckV2WithNullablePortPreservesNullAndValue(t *testing.T) {
 			}
 			if resp.Test.Port.Value == nil || *resp.Test.Port.Value != tt.wantValue {
 				t.Fatalf("response port = %#v, want %d", resp.Test.Port.Value, tt.wantValue)
+			}
+			if resp.Test.CertificateID == nil || resp.Test.CertificateID.Value == nil || *resp.Test.CertificateID.Value != 123 {
+				t.Fatalf("response certificate ID = %#v, want 123", resp.Test.CertificateID)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Preserves HTTP V2 client-certificate support when callers use the existing nullable-port request and response models.

## Problem

`HttpCheckV2Input` and `HttpCheckV2Response` include `certificateId`, while `HttpCheckV2InputWithNullablePort` and `HttpCheckV2ResponseWithNullablePort` do not. The Terraform provider must use the nullable-port models to represent an omitted HTTP port separately from an explicit `0`. Without this change, adopting those models for SYN-3601 would silently omit or lose the HTTP client-certificate association added by SYN-5402.

## Changes

- Add `certificateId` to `HttpCheckV2InputWithNullablePort`.
- Add `certificateId` to `HttpCheckV2ResponseWithNullablePort`.
- Verify create serializes a configured certificate ID.
- Verify update serializes explicit `null` for certificate removal.
- Verify get parses the certificate ID alongside nullable port values.

## Compatibility

This is additive and preserves the existing JSON field name and nullable semantics. Existing callers that do not set a certificate ID are unchanged.

## Validation

- `go test ./... -tags=unit_tests -count=1 -timeout=60s`
- `go vet -tags=unit_tests ./...`
- `go build -tags=unit_tests ./...`
- `golangci-lint run ./syntheticsclientv2/...`
- `git diff --check`

## Related

- [SYN-3601](https://splunk.atlassian.net/browse/SYN-3601)
- [terraform-provider-synthetics#90](https://github.com/splunk/terraform-provider-synthetics/pull/90)
- [terraform-provider-synthetics#97](https://github.com/splunk/terraform-provider-synthetics/pull/97)
