### PR TITLE
Add synthetics teams as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for all files in this repository.
+* @splunk/o11y-synthetics-admins @splunk/o11y-synthetics-approvers @splunk/o11y-synthetics-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for all files in this repository.
-* @splunk/o11y-synthetics-admins @splunk/o11y-synthetics-approvers @splunk/o11y-synthetics-maintainers
+* @splunk/o11y-synthetics-approvers @splunk/o11y-synthetics-maintainers


### PR DESCRIPTION
## Summary

- Add `.github/CODEOWNERS`.
- Make the synthetics approvers and maintainers teams owners of every repository file.

## Why

This establishes explicit ownership and lets GitHub request the three synthetics teams when pull requests change any file in the repository.

## Impact

All paths match the wildcard ownership rule. This is repository configuration only and does not change client runtime behavior.

## Validation

- Confirmed the branch differs from `v2` by only `.github/CODEOWNERS`.
- Confirmed the wildcard rule contains `@splunk/o11y-synthetics-approvers`, and `@splunk/o11y-synthetics-maintainers`.