### PR TITLE
SYN-6879: allow removing HTTP headers and valueless Chrome flags

### DIFF
--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -715,7 +715,7 @@ type HttpCheckV2Input struct {
 		UserAgent          *string            `json:"userAgent"`
 		Verifycertificates bool               `json:"verifyCertificates"`
 		CertificateID      *NullableInt       `json:"certificateId,omitempty"`
-		HttpHeaders        []HttpHeaders      `json:"headers"`
+		HttpHeaders        *[]HttpHeaders     `json:"headers,omitempty"`
 		Validations        []Validations      `json:"validations"`
 		Customproperties   []CustomProperties `json:"customProperties"`
 		Automaticretries   int                `json:"automaticRetries"`
@@ -768,7 +768,7 @@ type HttpCheckV2InputWithNullablePort struct {
 		UserAgent          *string            `json:"userAgent"`
 		Verifycertificates bool               `json:"verifyCertificates"`
 		CertificateID      *NullableInt       `json:"certificateId,omitempty"`
-		HttpHeaders        []HttpHeaders      `json:"headers"`
+		HttpHeaders        *[]HttpHeaders     `json:"headers,omitempty"`
 		Validations        []Validations      `json:"validations"`
 		Customproperties   []CustomProperties `json:"customProperties"`
 		Automaticretries   int                `json:"automaticRetries"`

--- a/syntheticsclientv2/common_models.go
+++ b/syntheticsclientv2/common_models.go
@@ -110,8 +110,8 @@ type Advancedsettings struct {
 }
 
 type ChromeFlag struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
+	Name  string  `json:"name"`
+	Value *string `json:"value,omitempty"`
 }
 
 type ChromeFlagsResponse struct {
@@ -715,7 +715,7 @@ type HttpCheckV2Input struct {
 		UserAgent          *string            `json:"userAgent"`
 		Verifycertificates bool               `json:"verifyCertificates"`
 		CertificateID      *NullableInt       `json:"certificateId,omitempty"`
-		HttpHeaders        []HttpHeaders      `json:"headers,omitempty"`
+		HttpHeaders        []HttpHeaders      `json:"headers"`
 		Validations        []Validations      `json:"validations"`
 		Customproperties   []CustomProperties `json:"customProperties"`
 		Automaticretries   int                `json:"automaticRetries"`
@@ -768,7 +768,7 @@ type HttpCheckV2InputWithNullablePort struct {
 		UserAgent          *string            `json:"userAgent"`
 		Verifycertificates bool               `json:"verifyCertificates"`
 		CertificateID      *NullableInt       `json:"certificateId,omitempty"`
-		HttpHeaders        []HttpHeaders      `json:"headers,omitempty"`
+		HttpHeaders        []HttpHeaders      `json:"headers"`
 		Validations        []Validations      `json:"validations"`
 		Customproperties   []CustomProperties `json:"customProperties"`
 		Automaticretries   int                `json:"automaticRetries"`

--- a/syntheticsclientv2/httpcheckv2_nullable_port_test.go
+++ b/syntheticsclientv2/httpcheckv2_nullable_port_test.go
@@ -159,6 +159,36 @@ func TestGetHttpCheckV2WithNullablePortPreservesNullAndValue(t *testing.T) {
 	}
 }
 
+// SYN-6879 / GitHub #73: clearing all headers must send an explicit empty
+// list so the API removes existing headers, rather than omitting the field.
+func TestUpdateHttpCheckV2WithNullablePortSendsExplicitEmptyHeaders(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests/http/14", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		fields := readHttpV2NullablePortRequestFields(t, r)
+		rawHeaders, ok := fields["headers"]
+		if !ok {
+			t.Fatal("request body missing test.headers, want explicit empty array")
+		}
+		if string(rawHeaders) != "[]" {
+			t.Fatalf("request body test.headers = %s, want []", rawHeaders)
+		}
+		_, err := w.Write([]byte(`{"test":{"id":14,"name":"nullable-port","type":"http","url":"https://example.com","requestMethod":"GET","port":null}}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	input := minimalHttpCheckV2InputWithNullablePort()
+	input.Test.HttpHeaders = []HttpHeaders{}
+
+	if _, _, err := testClient.UpdateHttpCheckV2WithNullablePort(14, &input); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func minimalHttpCheckV2InputWithNullablePort() HttpCheckV2InputWithNullablePort {
 	input := HttpCheckV2InputWithNullablePort{}
 	input.Test.Name = "nullable-port"

--- a/syntheticsclientv2/httpcheckv2_nullable_port_test.go
+++ b/syntheticsclientv2/httpcheckv2_nullable_port_test.go
@@ -182,9 +182,35 @@ func TestUpdateHttpCheckV2WithNullablePortSendsExplicitEmptyHeaders(t *testing.T
 	})
 
 	input := minimalHttpCheckV2InputWithNullablePort()
-	input.Test.HttpHeaders = []HttpHeaders{}
+	emptyHeaders := []HttpHeaders{}
+	input.Test.HttpHeaders = &emptyHeaders
 
 	if _, _, err := testClient.UpdateHttpCheckV2WithNullablePort(14, &input); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A caller that never touches HttpHeaders must still omit the field, so an
+// update that isn't managing headers doesn't unintentionally clear them.
+func TestUpdateHttpCheckV2WithNullablePortOmitsUnsetHeaders(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/tests/http/15", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		fields := readHttpV2NullablePortRequestFields(t, r)
+		if rawHeaders, ok := fields["headers"]; ok {
+			t.Fatalf("request body test.headers = %s, want field omitted for an unset HttpHeaders", rawHeaders)
+		}
+		_, err := w.Write([]byte(`{"test":{"id":15,"name":"nullable-port","type":"http","url":"https://example.com","requestMethod":"GET","port":null}}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	input := minimalHttpCheckV2InputWithNullablePort()
+
+	if _, _, err := testClient.UpdateHttpCheckV2WithNullablePort(15, &input); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/syntheticsclientv2/update_browsercheckv2_test.go
+++ b/syntheticsclientv2/update_browsercheckv2_test.go
@@ -164,6 +164,7 @@ func TestUpdateBrowserCheckV2SerializesCertificateIDs(t *testing.T) {
 
 func TestUpdateBrowserCheckV2PreservesAdvancedSettingsFields(t *testing.T) {
 	userAgent := "syntheticsclient-test-agent"
+	chromeFlagValue := "127.0.0.1:8080"
 	input := BrowserCheckV2Input{}
 	input.Test.Name = "browser-advanced-settings"
 	input.Test.Authentication = &Authentication{
@@ -198,7 +199,7 @@ func TestUpdateBrowserCheckV2PreservesAdvancedSettingsFields(t *testing.T) {
 	input.Test.ChromeFlags = []ChromeFlag{
 		{
 			Name:  "--proxy-bypass-list",
-			Value: "127.0.0.1:8080",
+			Value: &chromeFlagValue,
 		},
 	}
 	input.Test.ExcludedFiles = []ExcludedFile{
@@ -228,6 +229,40 @@ func TestUpdateBrowserCheckV2PreservesAdvancedSettingsFields(t *testing.T) {
 		if !reflect.DeepEqual(actual, expected) {
 			t.Fatalf("expected advancedSettings.%s to be %#v, but saw %#v in body: %s", key, expected, actual, requestBody)
 		}
+	}
+}
+
+// SYN-6879 / GitHub #82: a Chrome flag that is valid without a value (e.g.
+// --disable-web-security) must omit "value" entirely, distinct from a flag
+// carrying an explicit empty-string value.
+func TestUpdateBrowserCheckV2SerializesValuelessChromeFlag(t *testing.T) {
+	input := BrowserCheckV2Input{}
+	input.Test.Name = "browser-valueless-chrome-flag"
+	proxyValue := "127.0.0.1:8080"
+	input.Test.ChromeFlags = []ChromeFlag{
+		{Name: "--disable-web-security", Value: nil},
+		{Name: "--proxy-bypass-list", Value: &proxyValue},
+	}
+
+	requestBody := captureUpdateBrowserCheckV2RequestBody(t, input)
+
+	advancedSettings := browserCheckV2RequestAdvancedSettingsPayload(t, requestBody)
+	chromeFlags, ok := advancedSettings["chromeFlags"].([]interface{})
+	if !ok || len(chromeFlags) != 2 {
+		t.Fatalf("expected advancedSettings.chromeFlags to have 2 entries, but saw %#v in body: %s", advancedSettings["chromeFlags"], requestBody)
+	}
+
+	valueless, ok := chromeFlags[0].(map[string]interface{})
+	if !ok || valueless["name"] != "--disable-web-security" {
+		t.Fatalf("expected chromeFlags[0].name = --disable-web-security, but saw %#v in body: %s", chromeFlags[0], requestBody)
+	}
+	if _, ok := valueless["value"]; ok {
+		t.Fatalf("expected chromeFlags[0] to omit value entirely, but saw %#v in body: %s", valueless, requestBody)
+	}
+
+	withValue, ok := chromeFlags[1].(map[string]interface{})
+	if !ok || withValue["name"] != "--proxy-bypass-list" || withValue["value"] != "127.0.0.1:8080" {
+		t.Fatalf("expected chromeFlags[1] to preserve name/value, but saw %#v in body: %s", chromeFlags[1], requestBody)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes two defects tracked by [SYN-6879](https://splunk.atlassian.net/browse/SYN-6879):

- splunk/terraform-provider-synthetics#73 — HTTP check headers cannot be removed once configured
- splunk/terraform-provider-synthetics#82 — Chrome flags that are valid without a value (e.g. `--disable-web-security`) cannot be represented

**Note on versioning:** both fixes require breaking Go API changes (see "Backward compatibility" below), so this will be released as a new major version — `github.com/splunk/syntheticsclient/v3`, tagged `v3.0.0` — not a `v2` minor bump.

### #73 — HTTP headers can't be removed

`HttpCheckV2Input.Test.HttpHeaders` and `HttpCheckV2InputWithNullablePort.Test.HttpHeaders` were tagged `[]HttpHeaders json:"headers,omitempty"`. When a caller clears all headers, the resulting slice has length 0, `omitempty` drops the `headers` key from the PUT body entirely, and the API never receives an instruction to remove existing headers.

**Fix:** change `HttpHeaders` to `*[]HttpHeaders` with `json:"headers,omitempty"` on the two *input* structs only:
- `nil` (field never touched) → key omitted, same behavior as before this PR.
- non-nil pointer to an empty slice (explicit removal) → serializes as `"headers":[]`.
- non-nil pointer to a populated slice → normal array, unchanged.

The two *response* structs (`HttpCheckV2Response`, `HttpCheckV2ResponseWithNullablePort`) are unmarshal targets and are left unchanged.

*(Originally landed as a plain `omitempty` removal on `[]HttpHeaders`, which [review feedback](https://github.com/splunk/syntheticsclient/pull/50#discussion_r3709002968) correctly flagged as its own regression: an unset slice would then marshal as an explicit `"headers":null` on every create/update, not just the intended empty-slice case. Switched to `*[]HttpHeaders` to keep the three states — unset, explicitly empty, populated — distinct.)*

### #82 — valueless Chrome flags unsupported

`ChromeFlag.Value` was a plain `string` with no `omitempty`, so every flag — including ones that are only valid without a value, like `--disable-web-security` — always serialized `"value":""`, indistinguishable from a flag that genuinely carries an empty string.

**Fix:** change `ChromeFlag.Value` to `*string` with `json:"value,omitempty"`. A `nil` pointer omits the key (valueless flag); a non-nil pointer sends the value, including an explicit empty string if a caller ever needs that.

## Backward compatibility

**Go API (source): not backward compatible — this is a breaking change.** Two field type changes:
- `ChromeFlag.Value` changes from `string` to `*string`. Any existing caller constructing `ChromeFlag{Value: "x"}` or reading `flag.Value` as a string will fail to compile.
- `HttpHeaders` on `HttpCheckV2Input.Test` and `HttpCheckV2InputWithNullablePort.Test` changes from `[]HttpHeaders` to `*[]HttpHeaders`. A caller assigning `input.Test.HttpHeaders = someSlice` needs to switch to `&someSlice`; a caller reading it needs to dereference.

- Searched the `splunk` GitHub org (`gh search code "syntheticsclient/v2"`) and confirmed `terraform-provider-synthetics` is the only consumer of this module.
- Per Go modules convention and semver, a breaking API change gets a new major module path. **This will ship as `github.com/splunk/syntheticsclient/v3`**, tagged `v3.0.0`, rather than a `v2.8.0` minor bump under the existing `/v2` path.
- Follow-up (after this PR merges): bump this repo's own `go.mod` module path to `.../v3`, tag `v3.0.0`, then update `terraform-provider-synthetics` to import `github.com/splunk/syntheticsclient/v3` and update `buildHttpHeadersData` / `buildChromeFlagsData` / `flattenChromeFlagsData` for the new pointer types — coordinated, not left dangling.

**Wire (JSON) compatibility:**
- **Responses** (`HttpCheckV2Response`, `HttpCheckV2ResponseWithNullablePort`, `ChromeFlagsResponse`, etc.): untouched. Fully backward compatible — a `*string` unmarshals fine whether the API sends a string, omits the key, or sends `null`.
- **Requests**: two narrow, intentional behavior changes (the fix itself), and everything else preserved:
  - A caller that never sets `HttpHeaders` still omits the `headers` key entirely — identical to current behavior.
  - A caller that explicitly sets `HttpHeaders` to an empty slice now sends `"headers":[]` instead of the field being dropped. Validated by precedent: the sibling `Advancedsettings.BrowserHeaders` field has used `json:"headers"` (no `omitempty`) all along and works against the live API, so the API is already known to accept an explicit empty `headers` array.
  - A nil Chrome-flag value now omits `value` instead of sending `"value":""`.
  - Populated header lists and valued Chrome flags serialize byte-for-byte identically to before.

## Regression check for removing `omitempty` on `HttpHeaders`

Confirmed via git history that this isn't reverting an intentional recent decision:
- `omitempty` on `HttpHeaders` predates any recent PR — present on `HttpCheckV2Input` since the original v2 API package (`ec28325`), and mechanically copied into `HttpCheckV2InputWithNullablePort` by the PR that added nullable-port support (SYN-3601).
- The one deliberate "omit empty optional fields" PR (#36) only touched `Cookiesv2` and `BrowserHeaders.Domain` — it never touched `HttpHeaders`.
- Library unit tests compare **response** fields via `reflect.DeepEqual`, not marshaled request bodies, so no existing test asserted on the omitted-vs-empty request behavior.

## Validation performed

- `go build ./...` — clean.
- `go vet -tags unit_tests ./...` — clean (test files are gated behind the `unit_tests` build tag; running without `-tags unit_tests` silently skips them).
- `go test ./... -tags=unit_tests -timeout=60s -parallel=4 -cover` — both packages pass, no regressions (`ok`, 57.6%/73.5% coverage).
- `gofmt -l .` — no formatting issues.
- Added regression tests exercising the marshaled request body over a mock HTTP server:
  - `TestUpdateHttpCheckV2WithNullablePortSendsExplicitEmptyHeaders` (`syntheticsclientv2/httpcheckv2_nullable_port_test.go`) — asserts an update with an explicitly empty header list sends `"headers":[]`.
  - `TestUpdateHttpCheckV2WithNullablePortOmitsUnsetHeaders` (`syntheticsclientv2/httpcheckv2_nullable_port_test.go`) — asserts an update that never touches `HttpHeaders` still omits the `headers` key (added in response to the review comment linked above).
  - `TestUpdateBrowserCheckV2SerializesValuelessChromeFlag` (`syntheticsclientv2/update_browsercheckv2_test.go`) — asserts a valueless Chrome flag omits `value` entirely while a flag with a value still round-trips correctly, in the same request.
- Fixed one resulting compile break in `update_browsercheckv2_test.go` (an existing `ChromeFlag{Value: "127.0.0.1:8080"}` literal) by switching to a `*string`.
- `golangci-lint` is not installed locally, so it was not run before opening this PR — relying on CI to run it.

## Scope / what's intentionally not in this PR

- No provider-side changes. `terraform-provider-synthetics` will be updated (go.mod bump, re-vendor, `buildChromeFlagsData`/`flattenChromeFlagsData`, acceptance tests, docs) in a follow-up once this is merged and a new version is tagged.
- No tagging/release performed as part of this PR.

